### PR TITLE
Introduce Unsafe native stub

### DIFF
--- a/java.base/pom.xml
+++ b/java.base/pom.xml
@@ -15,6 +15,10 @@
     <dependencies>
         <dependency>
             <groupId>org.qbicc</groupId>
+            <artifactId>qbicc-runtime-linux</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.qbicc</groupId>
             <artifactId>qbicc-runtime-posix</artifactId>
         </dependency>
         <dependency>

--- a/java.base/src/main/java/jdk/internal/misc/Unsafe$_native.java
+++ b/java.base/src/main/java/jdk/internal/misc/Unsafe$_native.java
@@ -1,0 +1,65 @@
+package jdk.internal.misc;
+
+import static org.qbicc.runtime.CNative.*;
+import static org.qbicc.runtime.posix.Unistd.*;
+import static org.qbicc.runtime.linux.Stdlib.*;
+
+import java.security.ProtectionDomain;
+
+import org.qbicc.runtime.Build;
+
+/**
+ *
+ */
+public final class Unsafe$_native {
+
+    public int pageSize() {
+        if (Build.isHost()) {
+            throw new UnsupportedOperationException("Cannot retrieve page size of target during build; it is not known");
+        }
+        return Unsafe$_runtime.PAGE_SIZE;
+    }
+
+    int getLoadAverage0(double[] loadavg, int nelems) {
+        if (Build.Target.isLinux()) {
+            _Float64[] values = new _Float64[nelems];
+            return getloadavg(values, word(nelems)).intValue();
+        }
+        return 0;
+    }
+
+    public void throwException(Throwable ee) throws Throwable {
+        throw ee;
+    }
+
+    public Class<?> defineClass0(String name, byte[] b, int off, int len,
+                                 ClassLoader loader,
+                                 ProtectionDomain protectionDomain) {
+        throw new UnsupportedOperationException("Cannot define classes at run time");
+    }
+
+    private Class<?> defineAnonymousClass0(Class<?> hostClass, byte[] data, Object[] cpPatches) {
+        throw new UnsupportedOperationException("Cannot define classes at run time");
+    }
+
+    @SuppressWarnings("ConstantConditions")
+    private Unsafe asUnsafe() {
+        return (Unsafe) (Object) this;
+    }
+
+
+    //TODO:
+
+    //unpark
+    //park
+
+    //allocateInstance
+
+    //allocateMemory0
+    //reallocateMemory0
+    //freeMemory0
+    //setMemory0
+    //copyMemory0
+    //copySwapMemory0
+
+}

--- a/java.base/src/main/java/jdk/internal/misc/Unsafe$_runtime.java
+++ b/java.base/src/main/java/jdk/internal/misc/Unsafe$_runtime.java
@@ -1,0 +1,26 @@
+package jdk.internal.misc;
+
+import static org.qbicc.runtime.posix.Unistd.*;
+
+import org.qbicc.runtime.Build;
+
+/**
+ * Runtime-initialized Unsafe constants.
+ */
+public final class Unsafe$_runtime {
+    static final int PAGE_SIZE;
+
+    static {
+        int pageSize;
+        if (Build.Target.isPosix()) {
+            pageSize = sysconf(_SC_PAGE_SIZE).intValue();
+            if (pageSize == -1) {
+                throw new InternalError("Can't read page size");
+            }
+        } else {
+            // won't appear in the native image unless it's actually not supported
+            throw new UnsupportedOperationException("page_size");
+        }
+        PAGE_SIZE = pageSize;
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -74,6 +74,11 @@
 
             <dependency>
                 <groupId>org.qbicc</groupId>
+                <artifactId>qbicc-runtime-linux</artifactId>
+                <version>${version.qbicc}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.qbicc</groupId>
                 <artifactId>qbicc-runtime-posix</artifactId>
                 <version>${version.qbicc}</version>
             </dependency>


### PR DESCRIPTION
This also introduces the idea of a holder class which would be implicitly runtime-initialized in order to facilitate functionality that needs to be done one time at runtime.

This approach has several drawbacks but it works as a stopgap until we can have some better non-initializer-based solution for one-time tasks.

Note that the behavior is not actually implemented in qbicc at this time but it should be possible to use the existing run time initialization infrastructure to support it. In the meantime it does no harm and is illustrative. If we choose another approach we can revert at that time.