### PR TITLE
Pom and annotation changes to prep for deployment

### DIFF
--- a/aggregate/pom.xml
+++ b/aggregate/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>org.qbicc.rt</groupId>
         <artifactId>qbicc-rt-parent</artifactId>
-        <version>11.0.1-SNAPSHOT</version>
+        <version>11.alpha.0.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>qbicc-rt</artifactId>

--- a/aggregate/pom.xml
+++ b/aggregate/pom.xml
@@ -18,22 +18,10 @@
     <packaging>pom</packaging>
 
     <dependencies>
-        <!-- Aggregated modules -->
-
+        <!-- Aggregated modules from this project -->
         <dependency>
             <groupId>${project.groupId}</groupId>
             <artifactId>qbicc-rt-java.base</artifactId>
-        </dependency>
-
-        <!-- Qbicc run time libraries -->
-
-        <dependency>
-            <groupId>org.qbicc</groupId>
-            <artifactId>qbicc-runtime-linux</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.qbicc</groupId>
-            <artifactId>qbicc-runtime-posix</artifactId>
         </dependency>
     </dependencies>
 </project>

--- a/annotation/pom.xml
+++ b/annotation/pom.xml
@@ -7,10 +7,13 @@
     <parent>
         <groupId>org.qbicc.rt</groupId>
         <artifactId>qbicc-rt-parent</artifactId>
-        <version>11.0.1-SNAPSHOT</version>
+        <version>11.alpha.0.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>qbicc-rt-annotation</artifactId>
+
+    <name>Qbicc Run Time: Annotation</name>
+    <description>Qbicc JDK run time annotation library</description>
 
     <properties>
         <maven.compiler.source>8</maven.compiler.source>

--- a/java.base/pom.xml
+++ b/java.base/pom.xml
@@ -35,6 +35,8 @@
     </dependencies>
 
     <build>
+        <sourceDirectory>target/combined-sources</sourceDirectory>
+
         <plugins>
             <plugin>
                 <groupId>${project.groupId}</groupId>
@@ -255,7 +257,7 @@
 
                                 <!-- our sources take precedence -->
                                 <resource>
-                                    <directory>${project.build.sourceDirectory}</directory>
+                                    <directory>${project.basedir}/src/main/java</directory>
                                 </resource>
                             </resources>
                         </configuration>
@@ -289,7 +291,40 @@
                 </executions>
             </plugin>
 
+            <plugin>
+                <artifactId>maven-source-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>attach-sources</id>
+                        <goals>
+                            <goal>jar</goal>
+                        </goals>
+                        <configuration>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
 
+            <plugin>
+                <artifactId>maven-javadoc-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>default</id>
+                        <goals>
+                            <goal>jar</goal>
+                        </goals>
+                        <configuration>
+                            <sourcepath>${project.build.directory}/combined-sources</sourcepath>
+                            <additionalOptions>
+                                <additionalOption>--add-reads</additionalOption>
+                                <additionalOption>java.base=ALL-UNNAMED</additionalOption>
+                            </additionalOptions>
+                            <failOnError>false</failOnError>
+                            <failOnWarnings>false</failOnWarnings>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
         </plugins>
     </build>
 </project>

--- a/java.base/pom.xml
+++ b/java.base/pom.xml
@@ -7,10 +7,13 @@
     <parent>
         <groupId>org.qbicc.rt</groupId>
         <artifactId>qbicc-rt-parent</artifactId>
-        <version>11.0.1-SNAPSHOT</version>
+        <version>11.alpha.0.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>qbicc-rt-java.base</artifactId>
+
+    <name>Qbicc Run Time: java.base</name>
+    <description>The Qbicc builder for the java.base JDK module</description>
 
     <dependencies>
         <dependency>

--- a/java.base/src/main/java/java/lang/SecurityManager.java
+++ b/java.base/src/main/java/java/lang/SecurityManager.java
@@ -39,7 +39,7 @@ import java.security.Permission;
 
 import org.qbicc.rt.annotation.Tracking;
 
-@Tracking("java.base/share/java/lang/SecurityManager.java")
+@Tracking("src/java.base/share/java/lang/SecurityManager.java")
 public class SecurityManager {
 
     public SecurityManager() {

--- a/java.base/src/main/java/java/security/AccessControlContext.java
+++ b/java.base/src/main/java/java/security/AccessControlContext.java
@@ -34,7 +34,7 @@ package java.security;
 
 import org.qbicc.rt.annotation.Tracking;
 
-@Tracking("java.base/share/java/security/AccessControlContext.java")
+@Tracking("src/java.base/share/java/security/AccessControlContext.java")
 public final class AccessControlContext {
     static final ProtectionDomain[] FAKE_CONTEXT = new ProtectionDomain[0];
 

--- a/java.base/src/main/java/java/security/AccessController.java
+++ b/java.base/src/main/java/java/security/AccessController.java
@@ -34,7 +34,7 @@ package java.security;
 
 import org.qbicc.rt.annotation.Tracking;
 
-@Tracking("java.base/share/java/security/AccessController.java")
+@Tracking("src/java.base/share/java/security/AccessController.java")
 public final class AccessController {
     private AccessController() { }
 

--- a/java.base/src/main/java/sun/net/NetHooks.java
+++ b/java.base/src/main/java/sun/net/NetHooks.java
@@ -42,8 +42,8 @@ import org.qbicc.rt.annotation.Tracking;
 /**
  * Defines static methods to be invoked prior to binding or connecting TCP sockets.
  */
-@Tracking("java.base/unix/classes/sun/net/NetHooks.java")
-@Tracking("java.base/windows/classes/sun/net/NetHooks.java")
+@Tracking("src/java.base/unix/classes/sun/net/NetHooks.java")
+@Tracking("src/java.base/windows/classes/sun/net/NetHooks.java")
 public final class NetHooks {
 
     /**

--- a/java.base/src/main/java/sun/nio/ch/DefaultAsynchronousChannelProvider.java
+++ b/java.base/src/main/java/sun/nio/ch/DefaultAsynchronousChannelProvider.java
@@ -37,10 +37,10 @@ import java.nio.channels.spi.AsynchronousChannelProvider;
 import org.qbicc.runtime.Build;
 import org.qbicc.rt.annotation.Tracking;
 
-@Tracking("java.base/aix/classes/sun/nio/ch/DefaultAsynchronousChannelProvider.java")
-@Tracking("java.base/linux/classes/sun/nio/ch/DefaultAsynchronousChannelProvider.java")
-@Tracking("java.base/macosx/classes/sun/nio/ch/DefaultAsynchronousChannelProvider.java")
-@Tracking("java.base/windows/classes/sun/nio/ch/DefaultAsynchronousChannelProvider.java")
+@Tracking("src/java.base/aix/classes/sun/nio/ch/DefaultAsynchronousChannelProvider.java")
+@Tracking("src/java.base/linux/classes/sun/nio/ch/DefaultAsynchronousChannelProvider.java")
+@Tracking("src/java.base/macosx/classes/sun/nio/ch/DefaultAsynchronousChannelProvider.java")
+@Tracking("src/java.base/windows/classes/sun/nio/ch/DefaultAsynchronousChannelProvider.java")
 public class DefaultAsynchronousChannelProvider {
     /**
      * Prevent instantiation.

--- a/java.base/src/main/java/sun/nio/ch/DefaultSelectorProvider.java
+++ b/java.base/src/main/java/sun/nio/ch/DefaultSelectorProvider.java
@@ -39,10 +39,10 @@ import org.qbicc.rt.annotation.Tracking;
 /**
  *
  */
-@Tracking("openjdk/src/java.base/aix/classes/sun/nio/ch/DefaultSelectorProvider.java")
-@Tracking("openjdk/src/java.base/linux/classes/sun/nio/ch/DefaultSelectorProvider.java")
-@Tracking("openjdk/src/java.base/macosx/classes/sun/nio/ch/DefaultSelectorProvider.java")
-@Tracking("openjdk/src/java.base/windows/classes/sun/nio/ch/DefaultSelectorProvider.java")
+@Tracking("src/java.base/aix/classes/sun/nio/ch/DefaultSelectorProvider.java")
+@Tracking("src/java.base/linux/classes/sun/nio/ch/DefaultSelectorProvider.java")
+@Tracking("src/java.base/macosx/classes/sun/nio/ch/DefaultSelectorProvider.java")
+@Tracking("src/java.base/windows/classes/sun/nio/ch/DefaultSelectorProvider.java")
 public class DefaultSelectorProvider {
 
     /**

--- a/java.base/src/main/java/sun/nio/ch/FileDispatcherImpl.java
+++ b/java.base/src/main/java/sun/nio/ch/FileDispatcherImpl.java
@@ -43,8 +43,8 @@ import jdk.internal.misc.JavaIOFileDescriptorAccess;
 import jdk.internal.misc.SharedSecrets;
 import sun.security.action.GetPropertyAction;
 
-@Tracking("java.base/unix/sun/nio/ch/FileDispatcherImpl.java")
-@Tracking("java.base/windows/sun/nio/ch/FileDispatcherImpl.java")
+@Tracking("src/java.base/unix/sun/nio/ch/FileDispatcherImpl.java")
+@Tracking("src/java.base/windows/sun/nio/ch/FileDispatcherImpl.java")
 class FileDispatcherImpl extends FileDispatcher {
 
     static {

--- a/java.base/src/main/java/sun/nio/ch/SocketOptionRegistry.java
+++ b/java.base/src/main/java/sun/nio/ch/SocketOptionRegistry.java
@@ -48,7 +48,7 @@ import org.qbicc.rt.annotation.Tracking;
 /**
  *
  */
-@Tracking("java.base/share/classes/sun/nio/ch/SocketOptionRegistry.java.template")
+@Tracking("src/java.base/share/classes/sun/nio/ch/SocketOptionRegistry.java.template")
 public class SocketOptionRegistry {
     private SocketOptionRegistry() { }
 

--- a/java.base/src/main/java/sun/nio/fs/DefaultFileSystemProvider.java
+++ b/java.base/src/main/java/sun/nio/fs/DefaultFileSystemProvider.java
@@ -41,10 +41,10 @@ import org.qbicc.rt.annotation.Tracking;
 /**
  *
  */
-@Tracking("openjdk/src/java.base/aix/classes/sun/nio/fs/DefaultFileSystemProvider.java")
-@Tracking("openjdk/src/java.base/linux/classes/sun/nio/fs/DefaultFileSystemProvider.java")
-@Tracking("openjdk/src/java.base/macosx/classes/sun/nio/fs/DefaultFileSystemProvider.java")
-@Tracking("openjdk/src/java.base/windows/classes/sun/nio/fs/DefaultFileSystemProvider.java")
+@Tracking("src/java.base/aix/classes/sun/nio/fs/DefaultFileSystemProvider.java")
+@Tracking("src/java.base/linux/classes/sun/nio/fs/DefaultFileSystemProvider.java")
+@Tracking("src/java.base/macosx/classes/sun/nio/fs/DefaultFileSystemProvider.java")
+@Tracking("src/java.base/windows/classes/sun/nio/fs/DefaultFileSystemProvider.java")
 public class DefaultFileSystemProvider {
     private static final FileSystemProvider INSTANCE;
     private static final FileSystem THE_FILE_SYSTEM;

--- a/java.base/src/main/java/sun/nio/fs/UnixConstants.java
+++ b/java.base/src/main/java/sun/nio/fs/UnixConstants.java
@@ -38,7 +38,7 @@ import org.qbicc.runtime.posix.SysStat;
 import org.qbicc.runtime.posix.Unistd;
 import org.qbicc.rt.annotation.Tracking;
 
-@Tracking("java.base/unix/classes/sun/nio/fs/UnixConstants.java.template")
+@Tracking("src/java.base/unix/classes/sun/nio/fs/UnixConstants.java.template")
 final class UnixConstants {
     private UnixConstants() {}
 

--- a/plugin/pom.xml
+++ b/plugin/pom.xml
@@ -144,6 +144,24 @@
                     <skip>true</skip>
                 </configuration>
             </plugin>
+            <plugin>
+                <artifactId>maven-source-plugin</artifactId>
+                <configuration>
+                    <skipSource>true</skipSource>
+                </configuration>
+            </plugin>
+            <plugin>
+                <artifactId>maven-javadoc-plugin</artifactId>
+                <configuration>
+                    <skip>true</skip>
+                </configuration>
+            </plugin>
+            <plugin>
+                <artifactId>maven-gpg-plugin</artifactId>
+                <configuration>
+                    <skip>true</skip>
+                </configuration>
+            </plugin>
         </plugins>
     </build>
 

--- a/plugin/pom.xml
+++ b/plugin/pom.xml
@@ -7,10 +7,13 @@
     <parent>
         <groupId>org.qbicc.rt</groupId>
         <artifactId>qbicc-rt-parent</artifactId>
-        <version>11.0.1-SNAPSHOT</version>
+        <version>11.alpha.0.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>qbicc-rt-openjdk-build-tools-maven-plugin</artifactId>
+
+    <name>Qbicc Build Tools Maven Plugin</name>
+    <description>Maven plugin adapter for JDK build tools</description>
 
     <packaging>maven-plugin</packaging>
 

--- a/pom.xml
+++ b/pom.xml
@@ -128,12 +128,75 @@
                     <artifactId>maven-surefire-plugin</artifactId>
                     <version>2.22.2</version>
                 </plugin>
+                <plugin>
+                    <artifactId>maven-gpg-plugin</artifactId>
+                    <version>3.0.1</version>
+                </plugin>
+                <plugin>
+                    <groupId>org.sonatype.plugins</groupId>
+                    <artifactId>nexus-staging-maven-plugin</artifactId>
+                    <version>1.6.7</version>
+                </plugin>
             </plugins>
         </pluginManagement>
         <plugins>
             <plugin>
                 <artifactId>maven-compiler-plugin</artifactId>
             </plugin>
+            <plugin>
+                <artifactId>maven-source-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>attach-sources</id>
+                        <goals>
+                            <goal>jar</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
         </plugins>
     </build>
+    <profiles>
+        <profile>
+            <id>release</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <artifactId>maven-javadoc-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <phase>package</phase>
+                                <goals>
+                                    <goal>jar</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                    <plugin>
+                        <artifactId>maven-gpg-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>sign-artifacts</id>
+                                <phase>verify</phase>
+                                <goals>
+                                    <goal>sign</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                    <plugin>
+                        <groupId>org.sonatype.plugins</groupId>
+                        <artifactId>nexus-staging-maven-plugin</artifactId>
+                        <extensions>true</extensions>
+                        <configuration>
+                            <serverId>ossrh</serverId>
+                            <nexusUrl>https://s01.oss.sonatype.org/</nexusUrl>
+                            <keepStagingRepositoryOnCloseRuleFailure>true</keepStagingRepositoryOnCloseRuleFailure>
+                            <autoReleaseAfterClose>true</autoReleaseAfterClose>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,10 @@
 
     <groupId>org.qbicc.rt</groupId>
     <artifactId>qbicc-rt-parent</artifactId>
-    <version>11.0.1-SNAPSHOT</version>
+    <version>11.alpha.0.1-SNAPSHOT</version>
+
+    <name>Qbicc Run Time: Parent POM</name>
+    <description>Parent POM of Qbicc run time libraries</description>
 
     <properties>
         <sh>/bin/sh</sh>


### PR DESCRIPTION
This changes the version scheme to `<jdk-version>.alpha.<minor>.<micro>`. Once we have final releases the scheme will be `<jdk-version>.<major>.<minor>.<micro>`.  N.b. in Maven `alpha` sorts before `0`.

This also cleans up the aggregate POM so that it only includes JDK modules, in preparation for a main PR which will use the aggregate POM to construct the boot class path automatically.

The last change is to update the `@Tracking` annotation usage to consistently use `openjdk` as a base directory.