### PR TITLE
better Array.newInstance and Array.multiNewArray

### DIFF
--- a/java.base/src/main/java/java/lang/reflect/Array$_native.java
+++ b/java.base/src/main/java/java/lang/reflect/Array$_native.java
@@ -2,70 +2,84 @@ package java.lang.reflect;
 
 import org.qbicc.runtime.main.CompilerIntrinsics;
 
+import static org.qbicc.runtime.CNative.*;
+
 public final class Array$_native {
 
     private static Object newArray(Class<?> componentType, int length) throws NegativeArraySizeException {
-        if (componentType == byte.class) {
-            return new byte[length];
-        } else if (componentType == boolean.class) {
-            return new boolean[length];
-        } else if (componentType == short.class) {
-            return new short[length];
-        } else if (componentType == char.class) {
-            return new char[length];
-        } else if (componentType == int.class) {
-            return new int[length];
-        }  else if (componentType == float.class) {
-            return new float[length];
-        }  else if (componentType == long.class) {
-            return new long[length];
-        } else if (componentType == double.class) {
-            return new double[length];
-        } else if (componentType == void.class) {
-            throw new IllegalArgumentException();
-        } else {
-            if (componentType == null) {
-                throw new NullPointerException();
-            }
-            int dimensions = 1;
-            while (componentType.isArray()) {
-                dimensions += 1;
-                componentType = componentType.getComponentType();
-            }
-            if (dimensions > 255) {
+        if (componentType.isPrimitive()) {
+            if (componentType == byte.class) {
+                return new byte[length];
+            } else if (componentType == boolean.class) {
+                return new boolean[length];
+            } else if (componentType == short.class) {
+                return new short[length];
+            } else if (componentType == char.class) {
+                return new char[length];
+            } else if (componentType == int.class) {
+                return new int[length];
+            } else if (componentType == float.class) {
+                return new float[length];
+            } else if (componentType == long.class) {
+                return new long[length];
+            } else if (componentType == double.class) {
+                return new double[length];
+            } else {
                 throw new IllegalArgumentException();
             }
-            return CompilerIntrinsics.emitNewReferenceArray(componentType, dimensions, length);
+        } else {
+            int componentDim = CompilerIntrinsics.getDimensionsFromClass(componentType).intValue();
+            if (componentDim == 0) {
+                return CompilerIntrinsics.emitNewReferenceArray(componentType, 1, length);
+            } else if (componentDim > 254) {
+                throw new IllegalArgumentException();
+            } else {
+                type_id leafTypeId = CompilerIntrinsics.getTypeIdFromClass(componentType);
+                Class<?> leafClass = CompilerIntrinsics.getClassFromTypeIdSimple(leafTypeId);
+                return CompilerIntrinsics.emitNewReferenceArray(leafClass, componentDim + 1, length);
+            }
         }
     }
 
     private static Object multiNewArray(Class<?> componentType, int[] dimensions) throws IllegalArgumentException, NegativeArraySizeException {
         int dimCount = dimensions.length;
+        Class<?> lastLeafType;
+        Class<?> leafType;
         if (componentType.isPrimitive()) {
+            if (componentType == void.class) {
+                throw new IllegalArgumentException();
+            }
             dimCount -= 1;
+            lastLeafType = componentType;
+            leafType = CompilerIntrinsics.getArrayClassOf(componentType);
         } else {
-            while (componentType.isArray()) {
-                dimCount += 1;
-                componentType = componentType.getComponentType();
+            int componentDim = CompilerIntrinsics.getDimensionsFromClass(componentType).intValue();
+            if (componentDim == 0) {
+                leafType = lastLeafType = componentType;
+            } else {
+                dimCount += componentDim;
+                type_id leafTypeId = CompilerIntrinsics.getTypeIdFromClass(componentType);
+                leafType = lastLeafType = CompilerIntrinsics.getClassFromTypeIdSimple(leafTypeId);
             }
         }
-        if (dimensions.length == 0 || dimCount > 255 || void.class == componentType) {
+
+        if (dimensions.length == 0 || dimCount > 255) {
             throw new IllegalArgumentException();
         }
-        return multiNewArrayHelper(componentType, dimCount, 0, dimensions);
+        return multiNewArrayHelper(leafType, dimCount, lastLeafType, 0, dimensions);
     }
 
-    private static Object multiNewArrayHelper(Class<?> leafElemType, int dimCount, int dimIdx, int[] dimensions) throws NegativeArraySizeException {
+    private static Object multiNewArrayHelper(Class<?> leafType, int dimCount, Class<?> lastLeafType, int dimIdx, int[] dimensions) throws NegativeArraySizeException {
         if (dimIdx == dimensions.length - 1) {
             if (dimCount > 0) {
-                return CompilerIntrinsics.emitNewReferenceArray(leafElemType, dimCount, dimensions[dimIdx]);
+                return CompilerIntrinsics.emitNewReferenceArray(leafType, dimCount, dimensions[dimIdx]);
             } else {
-                return newArray(leafElemType, dimensions[dimIdx]);
+                return newArray(lastLeafType, dimensions[dimIdx]);
             }
         }
-        Object[] spine = (Object[])CompilerIntrinsics.emitNewReferenceArray(leafElemType, dimCount, dimensions[dimIdx]);
+        Object[] spine = (Object[])CompilerIntrinsics.emitNewReferenceArray(leafType, dimCount, dimensions[dimIdx]);
         for (int i=0; i<dimensions[dimIdx]; i++) {
-            spine[i] = multiNewArrayHelper(leafElemType, dimCount-1, dimIdx+1, dimensions);
+            spine[i] = multiNewArrayHelper(leafType, dimCount-1, lastLeafType, dimIdx+1, dimensions);
         }
         return spine;
     }


### PR DESCRIPTION
Avoids looping to get dimensionCount, multiNewArray actually works for primitive arrays.

Needs the fixes in https://github.com/qbicc/qbicc/pull/937 and https://github.com/qbicc/qbicc/pull/939 to actually work, but I don't think it depends on anything more than qbicc-0.2.0 to compile (so should be mergeable before qbicc-0.3.0).
