### PR TITLE
Non-native monitor operations

### DIFF
--- a/java.base/pom.xml
+++ b/java.base/pom.xml
@@ -30,6 +30,10 @@
         </dependency>
         <dependency>
             <groupId>org.qbicc</groupId>
+            <artifactId>qbicc-runtime-main</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.qbicc</groupId>
             <artifactId>qbicc-runtime-posix</artifactId>
         </dependency>
         <dependency>

--- a/java.base/src/main/java/java/lang/Object$_aliases.java
+++ b/java.base/src/main/java/java/lang/Object$_aliases.java
@@ -1,0 +1,11 @@
+package java.lang;
+
+import org.qbicc.runtime.patcher.PatchClass;
+
+/**
+ *
+ */
+@PatchClass(Object.class)
+class Object$_aliases {
+    native boolean holdsLock();
+}

--- a/java.base/src/main/java/java/lang/Thread$_native.java
+++ b/java.base/src/main/java/java/lang/Thread$_native.java
@@ -1,0 +1,7 @@
+package java.lang;
+
+class Thread$_native {
+    public static boolean holdsLock(Object obj) {
+        return ((Object$_aliases) obj).holdsLock();
+    }
+}

--- a/java.base/src/main/java/java/lang/Thread$_patch.java
+++ b/java.base/src/main/java/java/lang/Thread$_patch.java
@@ -69,9 +69,10 @@ public class Thread$_patch {
     static native long nextThreadID();
 
     // used only by non-Linux
-    @Add(unless = Build.Target.IsLinux.class)
+    // TODO: predicate class cannot be loaded before java.lang.Thread is loaded
+    // @Add(unless = Build.Target.IsLinux.class)
     pthread_mutex_t mutex;
-    @Add(unless = Build.Target.IsLinux.class)
+    // @Add(unless = Build.Target.IsLinux.class)
     pthread_cond_t cond;
     // used by Linux & POSIX
     @Add

--- a/java.base/src/main/resources/META-INF/qbicc/qbicc-patch-info
+++ b/java.base/src/main/resources/META-INF/qbicc/qbicc-patch-info
@@ -1,6 +1,7 @@
 # Patcher classes. Please keep sorted.
 
 jdk.internal.loader.BootLoader$_patch
+java.lang.Object$_aliases
 java.lang.Runtime$_runtime
 java.lang.Thread$_patch
 java.io.FileDescriptor$_runtime


### PR DESCRIPTION
Use `Monitor` for monitors.  Requires support from Qbicc that in turn requires this patch.  Because of how monitors were implemented, if Qbicc is not updated then the old monitor mechanism will still be used (intrinsics override most of these methods).  Once Qbicc is updated to remove the native monitor support, then these methods should start working.