### PR TITLE
adjustments to rtinitPhase1

### DIFF
--- a/java.base/src/main/java/java/lang/System$_patch.java
+++ b/java.base/src/main/java/java/lang/System$_patch.java
@@ -129,10 +129,13 @@ public final class System$_patch {
         VM.initializeOSEnvironment();
         */
 
+        /*
+         * MOVED to  rtinitPhase1
         // The main thread is not added to its thread group in the same
         // way as other threads; we must do it ourselves here.
         Thread current = Thread.currentThread();
         current.getThreadGroup().add(current);
+        */
 
         // Subsystems that are invoked during initialization can invoke
         // VM.isBooted() in order to avoid doing things that should
@@ -197,13 +200,20 @@ public final class System$_patch {
         setErr0(newPrintStream(fdErr, props.getProperty("sun.stderr.encoding")));
 
         // Setup Java signal handlers for HUP, TERM, and INT (where available).
-        Terminator.setup();
+        // TODO: need to implement Signal.findSignal0 first!
+        // Terminator.setup();
 
         // Initialize any miscellaneous operating system settings that need to be
         // set for the class libraries. Currently this is no-op everywhere except
         // for Windows where the process-wide error mode is set before the java.io
         // classes are used.
         VM.initializeOSEnvironment();
+
+        // The main thread is not added to its thread group in the same
+        // way as other threads; we must do it ourselves here.
+        // TODO: Need to actually implement this functionality
+        // Thread current = Thread.currentThread();
+        // current.getThreadGroup().add(current);
     }
 
     // The portions of System.initPhase2 that need to be  (re-)executed at runtime


### PR DESCRIPTION
1. Defer adding the main thread to the main thread group until rtinitPhase1.  This prevents us from getting a zombie build-time Thread object into the main ThreadGroup when we serialize it.
2. Be less aggressive in what we actually do in rtinitPhase1 (this code isn't actually executed without https://github.com/qbicc/qbicc/pull/1037, so I'd missed that some late additions to #96 involved natives we haven't actually implemented for real yet).

