### PR TITLE
Defer thread creations in JDK <clinit> to <rtinit>

### DIFF
--- a/java.base/src/main/java/java/lang/ref/Finalizer$_patch.java
+++ b/java.base/src/main/java/java/lang/ref/Finalizer$_patch.java
@@ -1,0 +1,10 @@
+package java.lang.ref;
+
+import org.qbicc.runtime.patcher.Add;
+import org.qbicc.runtime.patcher.PatchClass;
+
+@PatchClass(Finalizer.class)
+final class Finalizer$_patch {
+    // Alias
+    static native void runFinalization();
+}

--- a/java.base/src/main/java/java/lang/ref/Reference$_patch.java
+++ b/java.base/src/main/java/java/lang/ref/Reference$_patch.java
@@ -1,0 +1,53 @@
+package java.lang.ref;
+
+import jdk.internal.access.JavaLangRefAccess;
+import jdk.internal.access.SharedSecrets;
+
+import org.qbicc.runtime.patcher.Add;
+import org.qbicc.runtime.patcher.PatchClass;
+import org.qbicc.runtime.patcher.ReplaceInit;
+
+@PatchClass(Reference.class)
+@ReplaceInit
+public abstract class Reference$_patch<T> {
+    // Alias & preserve original <clinit>
+    private static final Object processPendingLock = new Object();
+    // Alias & preserve orginal <clinit>
+    private static boolean processPendingActive = false;
+
+    // Alias
+    private static native boolean waitForReferenceProcessing() throws InterruptedException;
+
+    static {
+        /*
+         * EXCLUDE from build-time <clinit> (eventually need to do at runtime).
+         *
+        ThreadGroup tg = Thread.currentThread().getThreadGroup();
+        for (ThreadGroup tgn = tg;
+             tgn != null;
+             tg = tgn, tgn = tg.getParent());
+        Thread handler = new ReferenceHandler(tg, "Reference Handler");
+        /* If there were a special system-only priority greater than
+         * MAX_PRIORITY, it would be used here
+         * /
+        handler.setPriority(Thread.MAX_PRIORITY);
+        handler.setDaemon(true);
+        handler.start();
+        */
+
+        // provide access in SharedSecrets
+        SharedSecrets.setJavaLangRefAccess(new JavaLangRefAccess() {
+            @Override
+            public boolean waitForReferenceProcessing()
+                    throws InterruptedException
+            {
+                return Reference$_patch.waitForReferenceProcessing();
+            }
+
+            @Override
+            public void runFinalization() {
+                Finalizer.runFinalization();
+            }
+        });
+    }
+}

--- a/java.base/src/main/java/jdk/internal/ref/CleanerFactory$_patch.java
+++ b/java.base/src/main/java/jdk/internal/ref/CleanerFactory$_patch.java
@@ -1,0 +1,16 @@
+package jdk.internal.ref;
+
+import jdk.internal.misc.InnocuousThread;
+
+import java.lang.ref.Cleaner;
+
+import org.qbicc.runtime.patcher.PatchClass;
+import org.qbicc.runtime.patcher.ReplaceInit;
+
+@PatchClass(CleanerFactory.class)
+@ReplaceInit
+public final class CleanerFactory$_patch {
+
+    // Disable at buildtime; moved to <rtinit>
+    private static final Cleaner commonCleaner = null;
+}

--- a/java.base/src/main/java/jdk/internal/ref/CleanerFactory$_runtime.java
+++ b/java.base/src/main/java/jdk/internal/ref/CleanerFactory$_runtime.java
@@ -1,0 +1,21 @@
+package jdk.internal.ref;
+
+import jdk.internal.misc.InnocuousThread;
+
+import java.lang.ref.Cleaner;
+import java.util.concurrent.ThreadFactory;
+
+import org.qbicc.runtime.patcher.PatchClass;
+import org.qbicc.runtime.patcher.RunTimeAspect;
+
+@PatchClass(CleanerFactory.class)
+@RunTimeAspect
+public final class CleanerFactory$_runtime {
+    private static final Cleaner commonCleaner = Cleaner.create(new ThreadFactory() {
+        @Override
+        public Thread newThread(Runnable r) {
+            return InnocuousThread.newSystemThread("Common-Cleaner",
+                    r, Thread.MAX_PRIORITY - 2);
+        }
+    });
+}

--- a/java.base/src/main/java/sun/security/provider/SeedGenerator$_patch.java
+++ b/java.base/src/main/java/sun/security/provider/SeedGenerator$_patch.java
@@ -1,0 +1,19 @@
+package sun.security.provider;
+
+import sun.security.util.Debug;
+
+import org.qbicc.runtime.patcher.Add;
+import org.qbicc.runtime.patcher.Patch;
+import org.qbicc.runtime.patcher.PatchClass;
+import org.qbicc.runtime.patcher.ReplaceInit;
+
+@PatchClass(sun.security.provider.SeedGenerator.class)
+@ReplaceInit
+class SeedGenerator$_patch {
+    static final Debug debug = Debug.getInstance("provider");
+
+    @Patch("sun.security.provider.SeedGenerator$ThreadedSeedGenerator")
+    static class ThreadedSeedGenerator$_patch {
+        ThreadedSeedGenerator$_patch() {}
+    }
+}

--- a/java.base/src/main/java/sun/security/provider/SeedGenerator$_runtime.java
+++ b/java.base/src/main/java/sun/security/provider/SeedGenerator$_runtime.java
@@ -1,0 +1,66 @@
+package sun.security.provider;
+
+import java.io.IOException;
+import sun.security.util.Debug;
+
+import org.qbicc.runtime.patcher.PatchClass;
+import org.qbicc.runtime.patcher.RunTimeAspect;
+
+@PatchClass(sun.security.provider.SeedGenerator.class)
+@RunTimeAspect
+class SeedGenerator$_runtime {
+    private static SeedGenerator instance;
+
+    // Static initializer to hook in selected or best performing generator
+    static {
+        String egdSource = SunEntries.getSeedSource();
+
+        /*
+         * Try the URL specifying the source (e.g. file:/dev/random)
+         *
+         * The URLs "file:/dev/random" or "file:/dev/urandom" are used to
+         * indicate the SeedGenerator should use OS support, if available.
+         *
+         * On Windows, this causes the MS CryptoAPI seeder to be used.
+         *
+         * On Solaris/Linux/MacOS, this is identical to using
+         * URLSeedGenerator to read from /dev/[u]random
+         */
+        if (egdSource.equals(SunEntries.URL_DEV_RANDOM) ||
+                egdSource.equals(SunEntries.URL_DEV_URANDOM)) {
+            try {
+                instance = new NativeSeedGenerator(egdSource);
+                if (SeedGenerator$_patch.debug != null) {
+                    SeedGenerator$_patch.debug.println(
+                            "Using operating system seed generator" + egdSource);
+                }
+            } catch (IOException e) {
+                if (SeedGenerator$_patch.debug != null) {
+                    SeedGenerator$_patch.debug.println("Failed to use operating system seed "
+                            + "generator: " + e.toString());
+                }
+            }
+        } else if (!egdSource.isEmpty()) {
+            try {
+                instance = new SeedGenerator.URLSeedGenerator(egdSource);
+                if (SeedGenerator$_patch.debug != null) {
+                    SeedGenerator$_patch.debug.println("Using URL seed generator reading from "
+                            + egdSource);
+                }
+            } catch (IOException e) {
+                if (SeedGenerator$_patch.debug != null) {
+                    SeedGenerator$_patch.debug.println("Failed to create seed generator with "
+                            + egdSource + ": " + e.toString());
+                }
+            }
+        }
+
+        // Fall back to ThreadedSeedGenerator
+        if (instance == null) {
+            if (SeedGenerator$_patch.debug != null) {
+                SeedGenerator$_patch.debug.println("Using default threaded seed generator");
+            }
+            instance = (SeedGenerator) (Object) new SeedGenerator$_patch.ThreadedSeedGenerator$_patch();
+        }
+    }
+}

--- a/java.base/src/main/resources/META-INF/qbicc/qbicc-patch-info
+++ b/java.base/src/main/resources/META-INF/qbicc/qbicc-patch-info
@@ -5,6 +5,8 @@ java.lang.Object$_aliases
 java.lang.Runtime$_runtime
 java.lang.System$_patch
 java.lang.Thread$_patch
+java.lang.ref.Reference$_patch
+java.lang.ref.Finalizer$_patch
 java.io.FileDescriptor$_runtime
 jdk.internal.misc.Unsafe$_runtime
 jdk.internal.misc.UnsafeParkUnpark

--- a/java.base/src/main/resources/META-INF/qbicc/qbicc-patch-info
+++ b/java.base/src/main/resources/META-INF/qbicc/qbicc-patch-info
@@ -14,3 +14,6 @@ jdk.internal.misc.UnsafeThreadAccess
 jdk.internal.ref.CleanerFactory$_patch
 jdk.internal.ref.CleanerFactory$_runtime
 sun.nio.ch.FileDispatcherImpl$_runtime
+sun.security.provider.SeedGenerator$_patch
+sun.security.provider.SeedGenerator$_patch$ThreadedSeedGenerator$_patch
+sun.security.provider.SeedGenerator$_runtime

--- a/java.base/src/main/resources/META-INF/qbicc/qbicc-patch-info
+++ b/java.base/src/main/resources/META-INF/qbicc/qbicc-patch-info
@@ -1,6 +1,5 @@
 # Patcher classes. Please keep sorted.
 
-jdk.internal.loader.BootLoader$_patch
 java.lang.Object$_aliases
 java.lang.Runtime$_runtime
 java.lang.System$_patch
@@ -8,7 +7,10 @@ java.lang.Thread$_patch
 java.lang.ref.Reference$_patch
 java.lang.ref.Finalizer$_patch
 java.io.FileDescriptor$_runtime
+jdk.internal.loader.BootLoader$_patch
 jdk.internal.misc.Unsafe$_runtime
 jdk.internal.misc.UnsafeParkUnpark
 jdk.internal.misc.UnsafeThreadAccess
+jdk.internal.ref.CleanerFactory$_patch
+jdk.internal.ref.CleanerFactory$_runtime
 sun.nio.ch.FileDispatcherImpl$_runtime


### PR DESCRIPTION
Handles all the <clinits> that cause thread.start() to be invoked in the interpreter (as observed in the debugger) with current classlib/qbicc combination.
