### PR TITLE
define rest of the "registerEmptyNativeInitMethods" intrinsics in Java

### DIFF
--- a/java.base/src/main/java/java/io/FileOutputStream$_native.java
+++ b/java.base/src/main/java/java/io/FileOutputStream$_native.java
@@ -51,4 +51,8 @@ public final class FileOutputStream$_native {
             len -= nw.intValue();
         }
     }
+
+    private static void initIDs() {
+        // no operation
+    }
 }

--- a/java.base/src/main/java/java/io/RandomAccessFile$_native.java
+++ b/java.base/src/main/java/java/io/RandomAccessFile$_native.java
@@ -1,0 +1,8 @@
+package java.io;
+
+public class RandomAccessFile$_native {
+
+    private static void initIDs() {
+        // no operation
+    }
+}

--- a/java.base/src/main/java/java/io/UnixFileSystem$_native.java
+++ b/java.base/src/main/java/java/io/UnixFileSystem$_native.java
@@ -152,5 +152,9 @@ class UnixFileSystem$_native {
         free(pathPtr);
         return accessRes.isNonZero();
     }
+
+    private static void initIDs() {
+        // no operation
+    }
 }
 

--- a/java.base/src/main/java/java/io/WinNTFileSystem$_native.java
+++ b/java.base/src/main/java/java/io/WinNTFileSystem$_native.java
@@ -1,0 +1,8 @@
+package java.io;
+
+public class WinNTFileSystem$_native {
+
+    private static void initIDs() {
+        // no operation
+    }
+}

--- a/java.base/src/main/java/java/lang/ClassLoader$_native.java
+++ b/java.base/src/main/java/java/lang/ClassLoader$_native.java
@@ -1,0 +1,7 @@
+package java.lang;
+
+public class ClassLoader$_native {
+    private static void registerNatives() {
+        // no-op
+    }
+}

--- a/java.base/src/main/java/java/lang/System$_native.java
+++ b/java.base/src/main/java/java/lang/System$_native.java
@@ -12,6 +12,10 @@ import org.qbicc.runtime.Build;
  */
 public final class System$_native {
 
+    private static void registerNatives() {
+        // no-op
+    }
+
     // Temporary manual implementation
     @SuppressWarnings("ManualArrayCopy")
     public static void arraycopy(Object src, int srcPos, Object dest, int destPos, int length) {

--- a/java.base/src/main/java/java/net/Inet4Address$_native.java
+++ b/java.base/src/main/java/java/net/Inet4Address$_native.java
@@ -1,0 +1,7 @@
+package java.net;
+
+public class Inet4Address$_native {
+    private static void init() {
+        // no-op
+    }
+}

--- a/java.base/src/main/java/java/net/Inet6Address$_native.java
+++ b/java.base/src/main/java/java/net/Inet6Address$_native.java
@@ -1,0 +1,7 @@
+package java.net;
+
+public class Inet6Address$_native {
+    private static void init() {
+        // no-op
+    }
+}

--- a/java.base/src/main/java/java/net/InetAddress$_native.java
+++ b/java.base/src/main/java/java/net/InetAddress$_native.java
@@ -1,0 +1,7 @@
+package java.net;
+
+public class InetAddress$_native {
+    private static void init() {
+        // no-op
+    }
+}

--- a/java.base/src/main/java/java/net/NetworkInterface$_native.java
+++ b/java.base/src/main/java/java/net/NetworkInterface$_native.java
@@ -1,0 +1,7 @@
+package java.net;
+
+public class NetworkInterface$_native {
+    private static void init() {
+        // no-op
+    }
+}

--- a/java.base/src/main/java/java/util/zip/Inflater$_native.java
+++ b/java.base/src/main/java/java/util/zip/Inflater$_native.java
@@ -1,0 +1,7 @@
+package java.util.zip;
+
+public class Inflater$_native {
+    private static void initIDs() {
+        // no-op
+    }
+}

--- a/java.base/src/main/java/jdk/internal/misc/ScopedMemoryAccess$_native.java
+++ b/java.base/src/main/java/jdk/internal/misc/ScopedMemoryAccess$_native.java
@@ -1,0 +1,7 @@
+package jdk.internal.misc;
+
+public class ScopedMemoryAccess$_native {
+    private static void registerNatives() {
+        // no-op
+    }
+}

--- a/java.base/src/main/java/jdk/internal/misc/Unsafe$_native.java
+++ b/java.base/src/main/java/jdk/internal/misc/Unsafe$_native.java
@@ -13,6 +13,10 @@ import org.qbicc.runtime.Build;
  */
 public final class Unsafe$_native {
 
+    private static void registerNatives() {
+        // no-op
+    }
+
     public int pageSize() {
         if (Build.isHost()) {
             throw new UnsupportedOperationException("Cannot retrieve page size of target during build; it is not known");

--- a/java.base/src/main/java/jdk/internal/misc/VM$_native.java
+++ b/java.base/src/main/java/jdk/internal/misc/VM$_native.java
@@ -1,0 +1,11 @@
+package jdk.internal.misc;
+
+public class VM$_native {
+    private static void initialize() {
+        // no-op
+    }
+
+    private static void initializeFromArchive(Class ignored) {
+        // no-op
+    }
+}

--- a/java.base/src/main/java/jdk/internal/perf/Perf$_native.java
+++ b/java.base/src/main/java/jdk/internal/perf/Perf$_native.java
@@ -1,0 +1,7 @@
+package jdk.internal.perf;
+
+public class Perf$_native {
+    private static void registerNatives() {
+        // no-op
+    }
+}

--- a/java.base/src/main/java/sun/nio/fs/AixNativeDispatcher$_native.java
+++ b/java.base/src/main/java/sun/nio/fs/AixNativeDispatcher$_native.java
@@ -1,0 +1,7 @@
+package sun.nio.fs;
+
+public class AixNativeDispatcher$_native {
+    private static void init() {
+        // no-op
+    }
+}

--- a/java.base/src/main/java/sun/nio/fs/BsdNativeDispatcher$_native.java
+++ b/java.base/src/main/java/sun/nio/fs/BsdNativeDispatcher$_native.java
@@ -1,0 +1,7 @@
+package sun.nio.fs;
+
+public class BsdNativeDispatcher$_native {
+    private static void initIDs() {
+        // no-op
+    }
+}

--- a/java.base/src/main/java/sun/nio/fs/LinuxNativeDispatcher$_native.java
+++ b/java.base/src/main/java/sun/nio/fs/LinuxNativeDispatcher$_native.java
@@ -1,0 +1,7 @@
+package sun.nio.fs;
+
+public class LinuxNativeDispatcher$_native {
+    private static void init() {
+        // no-op
+    }
+}

--- a/java.base/src/main/java/sun/nio/fs/SolarisNativeDispatcher$_native.java
+++ b/java.base/src/main/java/sun/nio/fs/SolarisNativeDispatcher$_native.java
@@ -1,0 +1,7 @@
+package sun.nio.fs;
+
+public class SolarisNativeDispatcher$_native {
+    private static void init() {
+        // no-op
+    }
+}

--- a/java.base/src/main/java/sun/nio/fs/WindowsNativeDispatcher$_native.java
+++ b/java.base/src/main/java/sun/nio/fs/WindowsNativeDispatcher$_native.java
@@ -1,0 +1,7 @@
+package sun.nio.fs;
+
+public class WindowsNativeDispatcher$_native {
+    private static void initIDs() {
+        // no-op
+    }
+}


### PR DESCRIPTION
mindless cleanup.... now that we have Foo$_native support, use it for the rest of these empty intrinsics. 