### PR TITLE
adjust build-time/runtime strategy for Cleaners

### DIFF
--- a/java.base/src/main/java/jdk/internal/org/qbicc/runtime/Main.java
+++ b/java.base/src/main/java/jdk/internal/org/qbicc/runtime/Main.java
@@ -60,9 +60,13 @@ public final class Main {
         System$_patch.rtinitPhase3();
 
         // next execute additional initialization actions deferred from build time
+        /*
+         * TODO: Have to sort out threading story first so that deamon threads created by
+         *       deferredInits don't prevent the process from exiting.
         for (Runnable r: deferredInits) {
             r.run();
         }
+        */
 
         // now cause the initial thread to invoke main
         final String[] args = new String[argc.intValue()];

--- a/java.base/src/main/java/jdk/internal/ref/CleanerImpl_Runnable1.java
+++ b/java.base/src/main/java/jdk/internal/ref/CleanerImpl_Runnable1.java
@@ -32,24 +32,24 @@
 
 package jdk.internal.ref;
 
-import jdk.internal.misc.InnocuousThread;
-
-import java.lang.ref.Cleaner;
 import java.util.concurrent.ThreadFactory;
 
-import org.qbicc.rt.annotation.Tracking;
-import org.qbicc.runtime.patcher.PatchClass;
-import org.qbicc.runtime.patcher.RunTimeAspect;
+/*
+ * This class exists because defining an anonymous Runnable in a patch class
+ * like CleanerImpl$_patch is not currently supported by our Patcher infrastructure.
+ */
+class CleanerImpl_Runnable1 implements Runnable {
+    final ThreadFactory tf;
+    final CleanerImpl ci;
 
-@PatchClass(CleanerFactory.class)
-@RunTimeAspect
-@Tracking("src/java.base/share/classes/jdk/internal/ref/CleanerFactory.java")
-public final class CleanerFactory$_runtime {
-    private static final Cleaner commonCleaner = Cleaner.create(new ThreadFactory() {
-        @Override
-        public Thread newThread(Runnable r) {
-            return InnocuousThread.newSystemThread("Common-Cleaner",
-                    r, Thread.MAX_PRIORITY - 2);
-        }
-    });
+    CleanerImpl_Runnable1(ThreadFactory tf, CleanerImpl ci) {
+        this.tf = tf;
+        this.ci = ci;
+    }
+
+    public void run() {
+        Thread thread = tf.newThread(ci);
+        thread.setDaemon(true);
+        thread.start();
+    }
 }

--- a/java.base/src/main/resources/META-INF/qbicc/qbicc-patch-info
+++ b/java.base/src/main/resources/META-INF/qbicc/qbicc-patch-info
@@ -22,8 +22,7 @@ jdk.internal.misc.UnsafeConstants$_runtime
 jdk.internal.misc.UnsafeParkUnpark
 jdk.internal.misc.UnsafeThreadAccess
 jdk.internal.misc.Unsafe$_patch
-jdk.internal.ref.CleanerFactory$_patch
-jdk.internal.ref.CleanerFactory$_runtime
+jdk.internal.ref.CleanerImpl$_patch
 sun.nio.ch.FileDispatcherImpl$_runtime
 sun.nio.fs.UnixFileAttributes$_aliases
 sun.security.provider.SeedGenerator$_patch


### PR DESCRIPTION
Allow Cleaners to be mostly initialized at build time while still
deferring the associated Thread creation and start until runtime.