### PR TITLE
sidestep gap in resolution of native methods with patch type parameters

### DIFF
--- a/java.base/src/main/java/sun/nio/fs/UnixNativeDispatcher$_native.java
+++ b/java.base/src/main/java/sun/nio/fs/UnixNativeDispatcher$_native.java
@@ -164,7 +164,7 @@ class UnixNativeDispatcher$_native {
         throw new UnsupportedOperationException();
     }
 
-    static void stat0(long pathAddress, UnixFileAttributes$_aliases attrs) throws UnixException {
+    static void stat0(long pathAddress, UnixFileAttributes attrs) throws UnixException {
         struct_stat buf = auto();
         int res;
         do {
@@ -189,7 +189,7 @@ class UnixNativeDispatcher$_native {
         }
     }
 
-    static void lstat0(long pathAddress, UnixFileAttributes$_aliases attrs) throws UnixException {
+    static void lstat0(long pathAddress, UnixFileAttributes attrs) throws UnixException {
         struct_stat buf = auto();
         int res;
         do {
@@ -201,7 +201,7 @@ class UnixNativeDispatcher$_native {
         prepAttributes(addr_of(buf), attrs);
    }
 
-    static void fstat(int fd, UnixFileAttributes$_aliases attrs) throws UnixException {
+    static void fstat(int fd, UnixFileAttributes attrs) throws UnixException {
         struct_stat buf = auto();
         int res;
         do {
@@ -213,7 +213,7 @@ class UnixNativeDispatcher$_native {
         prepAttributes(addr_of(buf), attrs);
     }
 
-    static void fstatat0(int dfd, long pathAddress, int flag, UnixFileAttributes$_aliases attrs) throws UnixException {
+    static void fstatat0(int dfd, long pathAddress, int flag, UnixFileAttributes attrs) throws UnixException {
         struct_stat buf = auto();
         int res;
         do {
@@ -380,18 +380,19 @@ class UnixNativeDispatcher$_native {
         throw new UnsupportedOperationException();
     }
 
-    private static void prepAttributes(final ptr<struct_stat> statBuf, final UnixFileAttributes$_aliases attrs) {
-        attrs.st_mode = addr_of(statBuf.sel().st_mode).loadUnshared().intValue();
-        attrs.st_ino = addr_of(statBuf.sel().st_ino).loadUnshared().longValue();
-        attrs.st_dev = addr_of(statBuf.sel().st_dev).loadUnshared().longValue();
-        attrs.st_rdev = addr_of(statBuf.sel().st_rdev).loadUnshared().longValue();
-        attrs.st_nlink = addr_of(statBuf.sel().st_nlink).loadUnshared().intValue();
-        attrs.st_uid = addr_of(statBuf.sel().st_uid).loadUnshared().intValue();
-        attrs.st_gid = addr_of(statBuf.sel().st_gid).loadUnshared().intValue();
-        attrs.st_size = addr_of(statBuf.sel().st_size).loadUnshared().longValue();
-        attrs.st_atime_sec = addr_of(statBuf.sel().st_atime).loadUnshared().longValue();
-        attrs.st_mtime_sec = addr_of(statBuf.sel().st_mtime).loadUnshared().longValue();
-        attrs.st_ctime_sec = addr_of(statBuf.sel().st_ctime).loadUnshared().longValue();
+    private static void prepAttributes(final ptr<struct_stat> statBuf, final UnixFileAttributes attrs) {
+        UnixFileAttributes$_aliases attrsAlias = (UnixFileAttributes$_aliases)(Object)attrs;
+        attrsAlias.st_mode = addr_of(statBuf.sel().st_mode).loadUnshared().intValue();
+        attrsAlias.st_ino = addr_of(statBuf.sel().st_ino).loadUnshared().longValue();
+        attrsAlias.st_dev = addr_of(statBuf.sel().st_dev).loadUnshared().longValue();
+        attrsAlias.st_rdev = addr_of(statBuf.sel().st_rdev).loadUnshared().longValue();
+        attrsAlias.st_nlink = addr_of(statBuf.sel().st_nlink).loadUnshared().intValue();
+        attrsAlias.st_uid = addr_of(statBuf.sel().st_uid).loadUnshared().intValue();
+        attrsAlias.st_gid = addr_of(statBuf.sel().st_gid).loadUnshared().intValue();
+        attrsAlias.st_size = addr_of(statBuf.sel().st_size).loadUnshared().longValue();
+        attrsAlias.st_atime_sec = addr_of(statBuf.sel().st_atime).loadUnshared().longValue();
+        attrsAlias.st_mtime_sec = addr_of(statBuf.sel().st_mtime).loadUnshared().longValue();
+        attrsAlias.st_ctime_sec = addr_of(statBuf.sel().st_ctime).loadUnshared().longValue();
         // todo: if (defined(_DARWIN_FEATURE_64_BIT_INODE)) {
         // todo:     attrs.st_birthtime = addr_of(statBuf.sel().st_birthtime).loadUnshared().longValue();
         // todo: }


### PR DESCRIPTION
We don't currently transform method descriptors to remove patching
types when defining a class.  Therefore the descriptors of the
methods in a $_native type have to exactly match the descriptor of
the method they are implementing (effectively a $_native class is
short hand for a Patch class with a @Replace annotation on every method,
and the descriptors also have to match for @Replace to work).