### PR TITLE
MethodHandle type checker

### DIFF
--- a/java.base/src/main/java/java/lang/invoke/MethodHandle$_patch.java
+++ b/java.base/src/main/java/java/lang/invoke/MethodHandle$_patch.java
@@ -1,0 +1,51 @@
+package java.lang.invoke;
+
+import org.qbicc.runtime.NoReflect;
+import org.qbicc.runtime.patcher.Add;
+import org.qbicc.runtime.patcher.PatchClass;
+
+/**
+ * Patches for method handle objects.
+ */
+@PatchClass(MethodHandle.class)
+abstract class MethodHandle$_patch {
+
+    // alias
+    public native MethodType type();
+
+    /**
+     * Check an exact call site type at run time.
+     *
+     * @param callSiteType the call site method type
+     * @throws WrongMethodTypeException if the types do not match
+     */
+    @Add
+    @NoReflect
+    final void checkType(MethodType callSiteType) {
+        Class<?> retType = callSiteType.returnType();
+        Class<?>[] argTypes = callSiteType.ptypes();
+        MethodType type = type();
+        if (retType != void.class && ! retType.isAssignableFrom(type.returnType())) {
+            // return type is incompatible
+            throw new WrongMethodTypeException();
+        }
+        // OK so far, the return type is compatible
+        int argCnt = argTypes.length;
+        int paramCnt = type.parameterCount();
+        if (argCnt < paramCnt) {
+            // not enough arguments
+            throw new WrongMethodTypeException();
+        }
+        // still OK, now check the parameters (extra arguments are ignored)
+        for (int i = 0; i < paramCnt; i ++) {
+            Class<?> parameterType = type.parameterType(i);
+            Class<?> argType = argTypes[i];
+            if (! parameterType.isAssignableFrom(argType)) {
+                // we cannot assign the parameter from the argument
+                throw new WrongMethodTypeException();
+            }
+        }
+        // all OK
+        return;
+    }
+}

--- a/java.base/src/main/resources/META-INF/qbicc/qbicc-patch-info
+++ b/java.base/src/main/resources/META-INF/qbicc/qbicc-patch-info
@@ -6,6 +6,7 @@ java.lang.ProcessEnvironment$_runtime
 java.lang.Runtime$_runtime
 java.lang.System$_patch
 java.lang.Thread$_patch
+java.lang.invoke.MethodHandle$_patch
 java.lang.invoke.MethodHandleNatives$CallSiteContext$_patch
 java.lang.ref.Reference$_patch
 java.lang.ref.Finalizer$_patch


### PR DESCRIPTION
Used at the call site for `invokeExact` to ensure that the called method matches the type of the call site.