### PR TITLE
Support for vtable-based `VarHandle`s

### DIFF
--- a/java.base/pom.xml
+++ b/java.base/pom.xml
@@ -144,9 +144,9 @@
                             <goal>generate-var-handles</goal>
                         </goals>
                         <configuration>
-                            <varHandleTemplateFile>${project.basedir}/../openjdk/src/java.base/share/classes/java/lang/invoke/X-VarHandle.java.template</varHandleTemplateFile>
-                            <varHandleByteArrayViewTemplateFile>${project.basedir}/../openjdk/src/java.base/share/classes/java/lang/invoke/X-VarHandleByteArrayView.java.template</varHandleByteArrayViewTemplateFile>
-                            <varHandleMemoryAccessHelperTemplateFile>${project.basedir}/../openjdk/src/java.base/share/classes/java/lang/invoke/X-VarHandleMemoryAccess.java.template</varHandleMemoryAccessHelperTemplateFile>
+                            <varHandleTemplateFile>${project.basedir}/src/main/java/java/lang/invoke/X-VarHandle.java.template</varHandleTemplateFile>
+                            <varHandleByteArrayViewTemplateFile>${project.basedir}/src/main/java/java/lang/invoke/X-VarHandleByteArrayView.java.template</varHandleByteArrayViewTemplateFile>
+                            <varHandleMemoryAccessHelperTemplateFile>${project.basedir}/src/main/java/java/lang/invoke/X-VarHandleMemoryAccess.java.template</varHandleMemoryAccessHelperTemplateFile>
                         </configuration>
                     </execution>
                     <execution>

--- a/java.base/src/main/java/java/lang/invoke/X-VarHandle.java.template
+++ b/java.base/src/main/java/java/lang/invoke/X-VarHandle.java.template
@@ -1,0 +1,1166 @@
+/*
+ * Copyright (c) 2015, 2019, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package java.lang.invoke;
+
+import jdk.internal.util.Preconditions;
+import jdk.internal.vm.annotation.ForceInline;
+
+import java.lang.invoke.VarHandle.VarHandleDesc;
+import java.util.Objects;
+import java.util.Optional;
+
+import static java.lang.invoke.MethodHandleStatics.UNSAFE;
+
+#warn
+
+final class VarHandle$Type$s {
+
+    static class FieldInstanceReadOnly extends VarHandle {
+        final long fieldOffset;
+        final Class<?> receiverType;
+#if[Object]
+        final Class<?> fieldType;
+#end[Object]
+
+        FieldInstanceReadOnly(Class<?> receiverType, long fieldOffset{#if[Object]?, Class<?> fieldType}) {
+            this(receiverType, fieldOffset{#if[Object]?, fieldType}, FieldInstanceReadOnly.FORM, false);
+        }
+
+        protected FieldInstanceReadOnly(Class<?> receiverType, long fieldOffset{#if[Object]?, Class<?> fieldType},
+                                        VarForm form, boolean exact) {
+            super(form, exact);
+            this.fieldOffset = fieldOffset;
+            this.receiverType = receiverType;
+#if[Object]
+            this.fieldType = fieldType;
+#end[Object]
+        }
+
+        @Override
+        public FieldInstanceReadOnly withInvokeExactBehavior() {
+            return hasInvokeExactBehavior()
+                ? this
+                : new FieldInstanceReadOnly(receiverType, fieldOffset{#if[Object]?, fieldType}, vform, true);
+        }
+
+        @Override
+        public FieldInstanceReadOnly withInvokeBehavior() {
+            return !hasInvokeExactBehavior()
+                ? this
+                : new FieldInstanceReadOnly(receiverType, fieldOffset{#if[Object]?, fieldType}, vform, false);
+        }
+
+        @Override
+        final MethodType accessModeTypeUncached(AccessType at) {
+            return at.accessModeType(receiverType, {#if[Object]?fieldType:$type$.class});
+        }
+
+        @Override
+        public Optional<VarHandleDesc> describeConstable() {
+            var receiverTypeRef = receiverType.describeConstable();
+            var fieldTypeRef = {#if[Object]?fieldType:$type$.class}.describeConstable();
+            if (!receiverTypeRef.isPresent() || !fieldTypeRef.isPresent())
+                return Optional.empty();
+
+            // Reflect on this VarHandle to extract the field name
+            String name = VarHandles.getFieldFromReceiverAndOffset(
+                receiverType, fieldOffset, {#if[Object]?fieldType:$type$.class}).getName();
+            return Optional.of(VarHandleDesc.ofField(receiverTypeRef.get(), name, fieldTypeRef.get()));
+        }
+
+        @ForceInline
+        static $type$ get(VarHandle ob, Object holder) {
+            FieldInstanceReadOnly handle = (FieldInstanceReadOnly)ob;
+            return UNSAFE.get$Type$(Objects.requireNonNull(handle.receiverType.cast(holder)),
+                                 handle.fieldOffset);
+        }
+
+        @ForceInline
+        static $type$ getVolatile(VarHandle ob, Object holder) {
+            FieldInstanceReadOnly handle = (FieldInstanceReadOnly)ob;
+            return UNSAFE.get$Type$Volatile(Objects.requireNonNull(handle.receiverType.cast(holder)),
+                                 handle.fieldOffset);
+        }
+
+        @ForceInline
+        static $type$ getOpaque(VarHandle ob, Object holder) {
+            FieldInstanceReadOnly handle = (FieldInstanceReadOnly)ob;
+            return UNSAFE.get$Type$Opaque(Objects.requireNonNull(handle.receiverType.cast(holder)),
+                                 handle.fieldOffset);
+        }
+
+        @ForceInline
+        static $type$ getAcquire(VarHandle ob, Object holder) {
+            FieldInstanceReadOnly handle = (FieldInstanceReadOnly)ob;
+            return UNSAFE.get$Type$Acquire(Objects.requireNonNull(handle.receiverType.cast(holder)),
+                                 handle.fieldOffset);
+        }
+
+        static final VarForm FORM = new VarForm(FieldInstanceReadOnly.class, Object.class, $type$.class);
+    }
+
+    static final class FieldInstanceReadWrite extends FieldInstanceReadOnly {
+
+        FieldInstanceReadWrite(Class<?> receiverType, long fieldOffset{#if[Object]?, Class<?> fieldType}) {
+            this(receiverType, fieldOffset{#if[Object]?, fieldType}, false);
+        }
+
+        private FieldInstanceReadWrite(Class<?> receiverType, long fieldOffset{#if[Object]?, Class<?> fieldType},
+                                       boolean exact) {
+            super(receiverType, fieldOffset{#if[Object]?, fieldType}, FieldInstanceReadWrite.FORM, exact);
+        }
+
+        @Override
+        public FieldInstanceReadWrite withInvokeExactBehavior() {
+            return hasInvokeExactBehavior()
+                ? this
+                : new FieldInstanceReadWrite(receiverType, fieldOffset{#if[Object]?, fieldType}, true);
+        }
+
+        @Override
+        public FieldInstanceReadWrite withInvokeBehavior() {
+            return !hasInvokeExactBehavior()
+                ? this
+                : new FieldInstanceReadWrite(receiverType, fieldOffset{#if[Object]?, fieldType}, false);
+        }
+
+        @ForceInline
+        static void set(VarHandle ob, Object holder, $type$ value) {
+            FieldInstanceReadWrite handle = (FieldInstanceReadWrite)ob;
+            UNSAFE.put$Type$(Objects.requireNonNull(handle.receiverType.cast(holder)),
+                             handle.fieldOffset,
+                             {#if[Object]?handle.fieldType.cast(value):value});
+        }
+
+        @ForceInline
+        static void setVolatile(VarHandle ob, Object holder, $type$ value) {
+            FieldInstanceReadWrite handle = (FieldInstanceReadWrite)ob;
+            UNSAFE.put$Type$Volatile(Objects.requireNonNull(handle.receiverType.cast(holder)),
+                                     handle.fieldOffset,
+                                     {#if[Object]?handle.fieldType.cast(value):value});
+        }
+
+        @ForceInline
+        static void setOpaque(VarHandle ob, Object holder, $type$ value) {
+            FieldInstanceReadWrite handle = (FieldInstanceReadWrite)ob;
+            UNSAFE.put$Type$Opaque(Objects.requireNonNull(handle.receiverType.cast(holder)),
+                                   handle.fieldOffset,
+                                   {#if[Object]?handle.fieldType.cast(value):value});
+        }
+
+        @ForceInline
+        static void setRelease(VarHandle ob, Object holder, $type$ value) {
+            FieldInstanceReadWrite handle = (FieldInstanceReadWrite)ob;
+            UNSAFE.put$Type$Release(Objects.requireNonNull(handle.receiverType.cast(holder)),
+                                    handle.fieldOffset,
+                                    {#if[Object]?handle.fieldType.cast(value):value});
+        }
+#if[CAS]
+
+        @ForceInline
+        static boolean compareAndSet(VarHandle ob, Object holder, $type$ expected, $type$ value) {
+            FieldInstanceReadWrite handle = (FieldInstanceReadWrite)ob;
+            return UNSAFE.compareAndSet$Type$(Objects.requireNonNull(handle.receiverType.cast(holder)),
+                                               handle.fieldOffset,
+                                               {#if[Object]?handle.fieldType.cast(expected):expected},
+                                               {#if[Object]?handle.fieldType.cast(value):value});
+        }
+
+        @ForceInline
+        static $type$ compareAndExchange(VarHandle ob, Object holder, $type$ expected, $type$ value) {
+            FieldInstanceReadWrite handle = (FieldInstanceReadWrite)ob;
+            return UNSAFE.compareAndExchange$Type$(Objects.requireNonNull(handle.receiverType.cast(holder)),
+                                               handle.fieldOffset,
+                                               {#if[Object]?handle.fieldType.cast(expected):expected},
+                                               {#if[Object]?handle.fieldType.cast(value):value});
+        }
+
+        @ForceInline
+        static $type$ compareAndExchangeAcquire(VarHandle ob, Object holder, $type$ expected, $type$ value) {
+            FieldInstanceReadWrite handle = (FieldInstanceReadWrite)ob;
+            return UNSAFE.compareAndExchange$Type$Acquire(Objects.requireNonNull(handle.receiverType.cast(holder)),
+                                               handle.fieldOffset,
+                                               {#if[Object]?handle.fieldType.cast(expected):expected},
+                                               {#if[Object]?handle.fieldType.cast(value):value});
+        }
+
+        @ForceInline
+        static $type$ compareAndExchangeRelease(VarHandle ob, Object holder, $type$ expected, $type$ value) {
+            FieldInstanceReadWrite handle = (FieldInstanceReadWrite)ob;
+            return UNSAFE.compareAndExchange$Type$Release(Objects.requireNonNull(handle.receiverType.cast(holder)),
+                                               handle.fieldOffset,
+                                               {#if[Object]?handle.fieldType.cast(expected):expected},
+                                               {#if[Object]?handle.fieldType.cast(value):value});
+        }
+
+        @ForceInline
+        static boolean weakCompareAndSetPlain(VarHandle ob, Object holder, $type$ expected, $type$ value) {
+            FieldInstanceReadWrite handle = (FieldInstanceReadWrite)ob;
+            return UNSAFE.weakCompareAndSet$Type$Plain(Objects.requireNonNull(handle.receiverType.cast(holder)),
+                                               handle.fieldOffset,
+                                               {#if[Object]?handle.fieldType.cast(expected):expected},
+                                               {#if[Object]?handle.fieldType.cast(value):value});
+        }
+
+        @ForceInline
+        static boolean weakCompareAndSet(VarHandle ob, Object holder, $type$ expected, $type$ value) {
+            FieldInstanceReadWrite handle = (FieldInstanceReadWrite)ob;
+            return UNSAFE.weakCompareAndSet$Type$(Objects.requireNonNull(handle.receiverType.cast(holder)),
+                                               handle.fieldOffset,
+                                               {#if[Object]?handle.fieldType.cast(expected):expected},
+                                               {#if[Object]?handle.fieldType.cast(value):value});
+        }
+
+        @ForceInline
+        static boolean weakCompareAndSetAcquire(VarHandle ob, Object holder, $type$ expected, $type$ value) {
+            FieldInstanceReadWrite handle = (FieldInstanceReadWrite)ob;
+            return UNSAFE.weakCompareAndSet$Type$Acquire(Objects.requireNonNull(handle.receiverType.cast(holder)),
+                                               handle.fieldOffset,
+                                               {#if[Object]?handle.fieldType.cast(expected):expected},
+                                               {#if[Object]?handle.fieldType.cast(value):value});
+        }
+
+        @ForceInline
+        static boolean weakCompareAndSetRelease(VarHandle ob, Object holder, $type$ expected, $type$ value) {
+            FieldInstanceReadWrite handle = (FieldInstanceReadWrite)ob;
+            return UNSAFE.weakCompareAndSet$Type$Release(Objects.requireNonNull(handle.receiverType.cast(holder)),
+                                               handle.fieldOffset,
+                                               {#if[Object]?handle.fieldType.cast(expected):expected},
+                                               {#if[Object]?handle.fieldType.cast(value):value});
+        }
+
+        @ForceInline
+        static $type$ getAndSet(VarHandle ob, Object holder, $type$ value) {
+            FieldInstanceReadWrite handle = (FieldInstanceReadWrite)ob;
+            return UNSAFE.getAndSet$Type$(Objects.requireNonNull(handle.receiverType.cast(holder)),
+                                          handle.fieldOffset,
+                                          {#if[Object]?handle.fieldType.cast(value):value});
+        }
+
+        @ForceInline
+        static $type$ getAndSetAcquire(VarHandle ob, Object holder, $type$ value) {
+            FieldInstanceReadWrite handle = (FieldInstanceReadWrite)ob;
+            return UNSAFE.getAndSet$Type$Acquire(Objects.requireNonNull(handle.receiverType.cast(holder)),
+                                          handle.fieldOffset,
+                                          {#if[Object]?handle.fieldType.cast(value):value});
+        }
+
+        @ForceInline
+        static $type$ getAndSetRelease(VarHandle ob, Object holder, $type$ value) {
+            FieldInstanceReadWrite handle = (FieldInstanceReadWrite)ob;
+            return UNSAFE.getAndSet$Type$Release(Objects.requireNonNull(handle.receiverType.cast(holder)),
+                                          handle.fieldOffset,
+                                          {#if[Object]?handle.fieldType.cast(value):value});
+        }
+#end[CAS]
+#if[AtomicAdd]
+
+        @ForceInline
+        static $type$ getAndAdd(VarHandle ob, Object holder, $type$ value) {
+            FieldInstanceReadWrite handle = (FieldInstanceReadWrite)ob;
+            return UNSAFE.getAndAdd$Type$(Objects.requireNonNull(handle.receiverType.cast(holder)),
+                                       handle.fieldOffset,
+                                       value);
+        }
+
+        @ForceInline
+        static $type$ getAndAddAcquire(VarHandle ob, Object holder, $type$ value) {
+            FieldInstanceReadWrite handle = (FieldInstanceReadWrite)ob;
+            return UNSAFE.getAndAdd$Type$Acquire(Objects.requireNonNull(handle.receiverType.cast(holder)),
+                                       handle.fieldOffset,
+                                       value);
+        }
+
+        @ForceInline
+        static $type$ getAndAddRelease(VarHandle ob, Object holder, $type$ value) {
+            FieldInstanceReadWrite handle = (FieldInstanceReadWrite)ob;
+            return UNSAFE.getAndAdd$Type$Release(Objects.requireNonNull(handle.receiverType.cast(holder)),
+                                       handle.fieldOffset,
+                                       value);
+        }
+
+#end[AtomicAdd]
+#if[Bitwise]
+
+        @ForceInline
+        static $type$ getAndBitwiseOr(VarHandle ob, Object holder, $type$ value) {
+            FieldInstanceReadWrite handle = (FieldInstanceReadWrite)ob;
+            return UNSAFE.getAndBitwiseOr$Type$(Objects.requireNonNull(handle.receiverType.cast(holder)),
+                                       handle.fieldOffset,
+                                       value);
+        }
+
+        @ForceInline
+        static $type$ getAndBitwiseOrRelease(VarHandle ob, Object holder, $type$ value) {
+            FieldInstanceReadWrite handle = (FieldInstanceReadWrite)ob;
+            return UNSAFE.getAndBitwiseOr$Type$Release(Objects.requireNonNull(handle.receiverType.cast(holder)),
+                                       handle.fieldOffset,
+                                       value);
+        }
+
+        @ForceInline
+        static $type$ getAndBitwiseOrAcquire(VarHandle ob, Object holder, $type$ value) {
+            FieldInstanceReadWrite handle = (FieldInstanceReadWrite)ob;
+            return UNSAFE.getAndBitwiseOr$Type$Acquire(Objects.requireNonNull(handle.receiverType.cast(holder)),
+                                       handle.fieldOffset,
+                                       value);
+        }
+
+        @ForceInline
+        static $type$ getAndBitwiseAnd(VarHandle ob, Object holder, $type$ value) {
+            FieldInstanceReadWrite handle = (FieldInstanceReadWrite)ob;
+            return UNSAFE.getAndBitwiseAnd$Type$(Objects.requireNonNull(handle.receiverType.cast(holder)),
+                                       handle.fieldOffset,
+                                       value);
+        }
+
+        @ForceInline
+        static $type$ getAndBitwiseAndRelease(VarHandle ob, Object holder, $type$ value) {
+            FieldInstanceReadWrite handle = (FieldInstanceReadWrite)ob;
+            return UNSAFE.getAndBitwiseAnd$Type$Release(Objects.requireNonNull(handle.receiverType.cast(holder)),
+                                       handle.fieldOffset,
+                                       value);
+        }
+
+        @ForceInline
+        static $type$ getAndBitwiseAndAcquire(VarHandle ob, Object holder, $type$ value) {
+            FieldInstanceReadWrite handle = (FieldInstanceReadWrite)ob;
+            return UNSAFE.getAndBitwiseAnd$Type$Acquire(Objects.requireNonNull(handle.receiverType.cast(holder)),
+                                       handle.fieldOffset,
+                                       value);
+        }
+
+        @ForceInline
+        static $type$ getAndBitwiseXor(VarHandle ob, Object holder, $type$ value) {
+            FieldInstanceReadWrite handle = (FieldInstanceReadWrite)ob;
+            return UNSAFE.getAndBitwiseXor$Type$(Objects.requireNonNull(handle.receiverType.cast(holder)),
+                                       handle.fieldOffset,
+                                       value);
+        }
+
+        @ForceInline
+        static $type$ getAndBitwiseXorRelease(VarHandle ob, Object holder, $type$ value) {
+            FieldInstanceReadWrite handle = (FieldInstanceReadWrite)ob;
+            return UNSAFE.getAndBitwiseXor$Type$Release(Objects.requireNonNull(handle.receiverType.cast(holder)),
+                                       handle.fieldOffset,
+                                       value);
+        }
+
+        @ForceInline
+        static $type$ getAndBitwiseXorAcquire(VarHandle ob, Object holder, $type$ value) {
+            FieldInstanceReadWrite handle = (FieldInstanceReadWrite)ob;
+            return UNSAFE.getAndBitwiseXor$Type$Acquire(Objects.requireNonNull(handle.receiverType.cast(holder)),
+                                       handle.fieldOffset,
+                                       value);
+        }
+#end[Bitwise]
+
+        static final VarForm FORM = new VarForm(FieldInstanceReadWrite.class, Object.class, $type$.class);
+    }
+
+
+    static class FieldStaticReadOnly extends VarHandle {
+        final Object base;
+        final long fieldOffset;
+#if[Object]
+        final Class<?> fieldType;
+#end[Object]
+
+        FieldStaticReadOnly(Object base, long fieldOffset{#if[Object]?, Class<?> fieldType}) {
+            this(base, fieldOffset{#if[Object]?, fieldType}, FieldStaticReadOnly.FORM, false);
+        }
+
+        protected FieldStaticReadOnly(Object base, long fieldOffset{#if[Object]?, Class<?> fieldType},
+                                      VarForm form, boolean exact) {
+            super(form, exact);
+            this.base = base;
+            this.fieldOffset = fieldOffset;
+#if[Object]
+            this.fieldType = fieldType;
+#end[Object]
+        }
+
+        @Override
+        public FieldStaticReadOnly withInvokeExactBehavior() {
+            return hasInvokeExactBehavior()
+                ? this
+                : new FieldStaticReadOnly(base, fieldOffset{#if[Object]?, fieldType}, vform, true);
+        }
+
+        @Override
+        public FieldStaticReadOnly withInvokeBehavior() {
+            return !hasInvokeExactBehavior()
+                ? this
+                : new FieldStaticReadOnly(base, fieldOffset{#if[Object]?, fieldType}, vform, false);
+        }
+
+        @Override
+        public Optional<VarHandleDesc> describeConstable() {
+            var fieldTypeRef = {#if[Object]?fieldType:$type$.class}.describeConstable();
+            if (!fieldTypeRef.isPresent())
+                return Optional.empty();
+
+            // Reflect on this VarHandle to extract the field name
+            var staticField = VarHandles.getStaticFieldFromBaseAndOffset(
+                base, fieldOffset, {#if[Object]?fieldType:$type$.class});
+            var receiverTypeRef = staticField.getDeclaringClass().describeConstable();
+            if (!receiverTypeRef.isPresent())
+                return Optional.empty();
+            return Optional.of(VarHandleDesc.ofStaticField(receiverTypeRef.get(), staticField.getName(), fieldTypeRef.get()));
+        }
+
+        @Override
+        final MethodType accessModeTypeUncached(AccessType at) {
+            return at.accessModeType(null, {#if[Object]?fieldType:$type$.class});
+        }
+
+        @ForceInline
+        static $type$ get(VarHandle ob) {
+            FieldStaticReadOnly handle = (FieldStaticReadOnly)ob;
+            return UNSAFE.get$Type$(handle.base,
+                                 handle.fieldOffset);
+        }
+
+        @ForceInline
+        static $type$ getVolatile(VarHandle ob) {
+            FieldStaticReadOnly handle = (FieldStaticReadOnly)ob;
+            return UNSAFE.get$Type$Volatile(handle.base,
+                                 handle.fieldOffset);
+        }
+
+        @ForceInline
+        static $type$ getOpaque(VarHandle ob) {
+            FieldStaticReadOnly handle = (FieldStaticReadOnly)ob;
+            return UNSAFE.get$Type$Opaque(handle.base,
+                                 handle.fieldOffset);
+        }
+
+        @ForceInline
+        static $type$ getAcquire(VarHandle ob) {
+            FieldStaticReadOnly handle = (FieldStaticReadOnly)ob;
+            return UNSAFE.get$Type$Acquire(handle.base,
+                                 handle.fieldOffset);
+        }
+
+        static final VarForm FORM = new VarForm(FieldStaticReadOnly.class, null, $type$.class);
+    }
+
+    static final class FieldStaticReadWrite extends FieldStaticReadOnly {
+
+        FieldStaticReadWrite(Object base, long fieldOffset{#if[Object]?, Class<?> fieldType}) {
+            this(base, fieldOffset{#if[Object]?, fieldType}, false);
+        }
+
+        private FieldStaticReadWrite(Object base, long fieldOffset{#if[Object]?, Class<?> fieldType},
+                                     boolean exact) {
+            super(base, fieldOffset{#if[Object]?, fieldType}, FieldStaticReadWrite.FORM, exact);
+        }
+
+        @Override
+        public FieldStaticReadWrite withInvokeExactBehavior() {
+            return hasInvokeExactBehavior()
+                ? this
+                : new FieldStaticReadWrite(base, fieldOffset{#if[Object]?, fieldType}, true);
+        }
+
+        @Override
+        public FieldStaticReadWrite withInvokeBehavior() {
+            return !hasInvokeExactBehavior()
+                ? this
+                : new FieldStaticReadWrite(base, fieldOffset{#if[Object]?, fieldType}, false);
+        }
+
+        @ForceInline
+        static void set(VarHandle ob, $type$ value) {
+            FieldStaticReadWrite handle = (FieldStaticReadWrite)ob;
+            UNSAFE.put$Type$(handle.base,
+                             handle.fieldOffset,
+                             {#if[Object]?handle.fieldType.cast(value):value});
+        }
+
+        @ForceInline
+        static void setVolatile(VarHandle ob, $type$ value) {
+            FieldStaticReadWrite handle = (FieldStaticReadWrite)ob;
+            UNSAFE.put$Type$Volatile(handle.base,
+                                     handle.fieldOffset,
+                                     {#if[Object]?handle.fieldType.cast(value):value});
+        }
+
+        @ForceInline
+        static void setOpaque(VarHandle ob, $type$ value) {
+            FieldStaticReadWrite handle = (FieldStaticReadWrite)ob;
+            UNSAFE.put$Type$Opaque(handle.base,
+                                   handle.fieldOffset,
+                                   {#if[Object]?handle.fieldType.cast(value):value});
+        }
+
+        @ForceInline
+        static void setRelease(VarHandle ob, $type$ value) {
+            FieldStaticReadWrite handle = (FieldStaticReadWrite)ob;
+            UNSAFE.put$Type$Release(handle.base,
+                                    handle.fieldOffset,
+                                    {#if[Object]?handle.fieldType.cast(value):value});
+        }
+#if[CAS]
+
+        @ForceInline
+        static boolean compareAndSet(VarHandle ob, $type$ expected, $type$ value) {
+            FieldStaticReadWrite handle = (FieldStaticReadWrite)ob;
+            return UNSAFE.compareAndSet$Type$(handle.base,
+                                               handle.fieldOffset,
+                                               {#if[Object]?handle.fieldType.cast(expected):expected},
+                                               {#if[Object]?handle.fieldType.cast(value):value});
+        }
+
+
+        @ForceInline
+        static $type$ compareAndExchange(VarHandle ob, $type$ expected, $type$ value) {
+            FieldStaticReadWrite handle = (FieldStaticReadWrite)ob;
+            return UNSAFE.compareAndExchange$Type$(handle.base,
+                                               handle.fieldOffset,
+                                               {#if[Object]?handle.fieldType.cast(expected):expected},
+                                               {#if[Object]?handle.fieldType.cast(value):value});
+        }
+
+        @ForceInline
+        static $type$ compareAndExchangeAcquire(VarHandle ob, $type$ expected, $type$ value) {
+            FieldStaticReadWrite handle = (FieldStaticReadWrite)ob;
+            return UNSAFE.compareAndExchange$Type$Acquire(handle.base,
+                                               handle.fieldOffset,
+                                               {#if[Object]?handle.fieldType.cast(expected):expected},
+                                               {#if[Object]?handle.fieldType.cast(value):value});
+        }
+
+        @ForceInline
+        static $type$ compareAndExchangeRelease(VarHandle ob, $type$ expected, $type$ value) {
+            FieldStaticReadWrite handle = (FieldStaticReadWrite)ob;
+            return UNSAFE.compareAndExchange$Type$Release(handle.base,
+                                               handle.fieldOffset,
+                                               {#if[Object]?handle.fieldType.cast(expected):expected},
+                                               {#if[Object]?handle.fieldType.cast(value):value});
+        }
+
+        @ForceInline
+        static boolean weakCompareAndSetPlain(VarHandle ob, $type$ expected, $type$ value) {
+            FieldStaticReadWrite handle = (FieldStaticReadWrite)ob;
+            return UNSAFE.weakCompareAndSet$Type$Plain(handle.base,
+                                               handle.fieldOffset,
+                                               {#if[Object]?handle.fieldType.cast(expected):expected},
+                                               {#if[Object]?handle.fieldType.cast(value):value});
+        }
+
+        @ForceInline
+        static boolean weakCompareAndSet(VarHandle ob, $type$ expected, $type$ value) {
+            FieldStaticReadWrite handle = (FieldStaticReadWrite)ob;
+            return UNSAFE.weakCompareAndSet$Type$(handle.base,
+                                               handle.fieldOffset,
+                                               {#if[Object]?handle.fieldType.cast(expected):expected},
+                                               {#if[Object]?handle.fieldType.cast(value):value});
+        }
+
+        @ForceInline
+        static boolean weakCompareAndSetAcquire(VarHandle ob, $type$ expected, $type$ value) {
+            FieldStaticReadWrite handle = (FieldStaticReadWrite)ob;
+            return UNSAFE.weakCompareAndSet$Type$Acquire(handle.base,
+                                               handle.fieldOffset,
+                                               {#if[Object]?handle.fieldType.cast(expected):expected},
+                                               {#if[Object]?handle.fieldType.cast(value):value});
+        }
+
+        @ForceInline
+        static boolean weakCompareAndSetRelease(VarHandle ob, $type$ expected, $type$ value) {
+            FieldStaticReadWrite handle = (FieldStaticReadWrite)ob;
+            return UNSAFE.weakCompareAndSet$Type$Release(handle.base,
+                                               handle.fieldOffset,
+                                               {#if[Object]?handle.fieldType.cast(expected):expected},
+                                               {#if[Object]?handle.fieldType.cast(value):value});
+        }
+
+        @ForceInline
+        static $type$ getAndSet(VarHandle ob, $type$ value) {
+            FieldStaticReadWrite handle = (FieldStaticReadWrite)ob;
+            return UNSAFE.getAndSet$Type$(handle.base,
+                                          handle.fieldOffset,
+                                          {#if[Object]?handle.fieldType.cast(value):value});
+        }
+
+        @ForceInline
+        static $type$ getAndSetAcquire(VarHandle ob, $type$ value) {
+            FieldStaticReadWrite handle = (FieldStaticReadWrite)ob;
+            return UNSAFE.getAndSet$Type$Acquire(handle.base,
+                                          handle.fieldOffset,
+                                          {#if[Object]?handle.fieldType.cast(value):value});
+        }
+
+        @ForceInline
+        static $type$ getAndSetRelease(VarHandle ob, $type$ value) {
+            FieldStaticReadWrite handle = (FieldStaticReadWrite)ob;
+            return UNSAFE.getAndSet$Type$Release(handle.base,
+                                          handle.fieldOffset,
+                                          {#if[Object]?handle.fieldType.cast(value):value});
+        }
+#end[CAS]
+#if[AtomicAdd]
+
+        @ForceInline
+        static $type$ getAndAdd(VarHandle ob, $type$ value) {
+            FieldStaticReadWrite handle = (FieldStaticReadWrite)ob;
+            return UNSAFE.getAndAdd$Type$(handle.base,
+                                       handle.fieldOffset,
+                                       value);
+        }
+
+        @ForceInline
+        static $type$ getAndAddAcquire(VarHandle ob, $type$ value) {
+            FieldStaticReadWrite handle = (FieldStaticReadWrite)ob;
+            return UNSAFE.getAndAdd$Type$Acquire(handle.base,
+                                       handle.fieldOffset,
+                                       value);
+        }
+
+        @ForceInline
+        static $type$ getAndAddRelease(VarHandle ob, $type$ value) {
+            FieldStaticReadWrite handle = (FieldStaticReadWrite)ob;
+            return UNSAFE.getAndAdd$Type$Release(handle.base,
+                                       handle.fieldOffset,
+                                       value);
+        }
+#end[AtomicAdd]
+#if[Bitwise]
+
+        @ForceInline
+        static $type$ getAndBitwiseOr(VarHandle ob, $type$ value) {
+            FieldStaticReadWrite handle = (FieldStaticReadWrite)ob;
+            return UNSAFE.getAndBitwiseOr$Type$(handle.base,
+                                       handle.fieldOffset,
+                                       value);
+        }
+
+        @ForceInline
+        static $type$ getAndBitwiseOrRelease(VarHandle ob, $type$ value) {
+            FieldStaticReadWrite handle = (FieldStaticReadWrite)ob;
+            return UNSAFE.getAndBitwiseOr$Type$Release(handle.base,
+                                       handle.fieldOffset,
+                                       value);
+        }
+
+        @ForceInline
+        static $type$ getAndBitwiseOrAcquire(VarHandle ob, $type$ value) {
+            FieldStaticReadWrite handle = (FieldStaticReadWrite)ob;
+            return UNSAFE.getAndBitwiseOr$Type$Acquire(handle.base,
+                                       handle.fieldOffset,
+                                       value);
+        }
+
+        @ForceInline
+        static $type$ getAndBitwiseAnd(VarHandle ob, $type$ value) {
+            FieldStaticReadWrite handle = (FieldStaticReadWrite)ob;
+            return UNSAFE.getAndBitwiseAnd$Type$(handle.base,
+                                       handle.fieldOffset,
+                                       value);
+        }
+
+        @ForceInline
+        static $type$ getAndBitwiseAndRelease(VarHandle ob, $type$ value) {
+            FieldStaticReadWrite handle = (FieldStaticReadWrite)ob;
+            return UNSAFE.getAndBitwiseAnd$Type$Release(handle.base,
+                                       handle.fieldOffset,
+                                       value);
+        }
+
+        @ForceInline
+        static $type$ getAndBitwiseAndAcquire(VarHandle ob, $type$ value) {
+            FieldStaticReadWrite handle = (FieldStaticReadWrite)ob;
+            return UNSAFE.getAndBitwiseAnd$Type$Acquire(handle.base,
+                                       handle.fieldOffset,
+                                       value);
+        }
+
+        @ForceInline
+        static $type$ getAndBitwiseXor(VarHandle ob, $type$ value) {
+            FieldStaticReadWrite handle = (FieldStaticReadWrite)ob;
+            return UNSAFE.getAndBitwiseXor$Type$(handle.base,
+                                       handle.fieldOffset,
+                                       value);
+        }
+
+        @ForceInline
+        static $type$ getAndBitwiseXorRelease(VarHandle ob, $type$ value) {
+            FieldStaticReadWrite handle = (FieldStaticReadWrite)ob;
+            return UNSAFE.getAndBitwiseXor$Type$Release(handle.base,
+                                       handle.fieldOffset,
+                                       value);
+        }
+
+        @ForceInline
+        static $type$ getAndBitwiseXorAcquire(VarHandle ob, $type$ value) {
+            FieldStaticReadWrite handle = (FieldStaticReadWrite)ob;
+            return UNSAFE.getAndBitwiseXor$Type$Acquire(handle.base,
+                                       handle.fieldOffset,
+                                       value);
+        }
+#end[Bitwise]
+
+        static final VarForm FORM = new VarForm(FieldStaticReadWrite.class, null, $type$.class);
+    }
+
+
+    static final class Array extends VarHandle {
+        final int abase;
+        final int ashift;
+#if[Object]
+        final Class<{#if[Object]??:$type$[]}> arrayType;
+        final Class<?> componentType;
+#end[Object]
+
+        Array(int abase, int ashift{#if[Object]?, Class<?> arrayType}) {
+            this(abase, ashift{#if[Object]?, arrayType}, false);
+        }
+
+        private Array(int abase, int ashift{#if[Object]?, Class<?> arrayType}, boolean exact) {
+            super(Array.FORM, exact);
+            this.abase = abase;
+            this.ashift = ashift;
+#if[Object]
+            this.arrayType = {#if[Object]?arrayType:$type$[].class};
+            this.componentType = arrayType.getComponentType();
+#end[Object]
+        }
+
+        @Override
+        public Array withInvokeExactBehavior() {
+            return hasInvokeExactBehavior()
+                ? this
+                : new Array(abase, ashift{#if[Object]?, arrayType}, true);
+        }
+
+        @Override
+        public Array withInvokeBehavior() {
+            return !hasInvokeExactBehavior()
+                ? this
+                : new Array(abase, ashift{#if[Object]?, arrayType}, false);
+        }
+
+        @Override
+        public Optional<VarHandleDesc> describeConstable() {
+            var arrayTypeRef = {#if[Object]?arrayType:$type$[].class}.describeConstable();
+            if (!arrayTypeRef.isPresent())
+                return Optional.empty();
+
+            return Optional.of(VarHandleDesc.ofArray(arrayTypeRef.get()));
+        }
+
+        @Override
+        final MethodType accessModeTypeUncached(AccessType at) {
+            return at.accessModeType({#if[Object]?arrayType:$type$[].class}, {#if[Object]?arrayType.getComponentType():$type$.class}, int.class);
+        }
+
+#if[Object]
+        @ForceInline
+        static Object runtimeTypeCheck(Array handle, Object[] oarray, Object value) {
+            if (handle.arrayType == oarray.getClass()) {
+                // Fast path: static array type same as argument array type
+                return handle.componentType.cast(value);
+            } else {
+                // Slow path: check value against argument array component type
+                return reflectiveTypeCheck(oarray, value);
+            }
+        }
+
+        @ForceInline
+        static Object reflectiveTypeCheck(Object[] oarray, Object value) {
+            try {
+                return oarray.getClass().getComponentType().cast(value);
+            } catch (ClassCastException e) {
+                throw new ArrayStoreException();
+            }
+        }
+#end[Object]
+
+        @ForceInline
+        static $type$ get(VarHandle ob, Object oarray, int index) {
+            Array handle = (Array)ob;
+#if[Object]
+            Object[] array = (Object[]) handle.arrayType.cast(oarray);
+#else[Object]
+            $type$[] array = ($type$[]) oarray;
+#end[Object]
+            return array[index];
+        }
+
+        @ForceInline
+        static void set(VarHandle ob, Object oarray, int index, $type$ value) {
+            Array handle = (Array)ob;
+#if[Object]
+            Object[] array = (Object[]) handle.arrayType.cast(oarray);
+#else[Object]
+            $type$[] array = ($type$[]) oarray;
+#end[Object]
+            array[index] = {#if[Object]?handle.componentType.cast(value):value};
+        }
+
+        @ForceInline
+        static $type$ getVolatile(VarHandle ob, Object oarray, int index) {
+            Array handle = (Array)ob;
+#if[Object]
+            Object[] array = (Object[]) handle.arrayType.cast(oarray);
+#else[Object]
+            $type$[] array = ($type$[]) oarray;
+#end[Object]
+            return UNSAFE.get$Type$Volatile(array,
+                    (((long) Preconditions.checkIndex(index, array.length, AIOOBE_SUPPLIER)) << handle.ashift) + handle.abase);
+        }
+
+        @ForceInline
+        static void setVolatile(VarHandle ob, Object oarray, int index, $type$ value) {
+            Array handle = (Array)ob;
+#if[Object]
+            Object[] array = (Object[]) handle.arrayType.cast(oarray);
+#else[Object]
+            $type$[] array = ($type$[]) oarray;
+#end[Object]
+            UNSAFE.put$Type$Volatile(array,
+                    (((long) Preconditions.checkIndex(index, array.length, AIOOBE_SUPPLIER)) << handle.ashift) + handle.abase,
+                    {#if[Object]?runtimeTypeCheck(handle, array, value):value});
+        }
+
+        @ForceInline
+        static $type$ getOpaque(VarHandle ob, Object oarray, int index) {
+            Array handle = (Array)ob;
+#if[Object]
+            Object[] array = (Object[]) handle.arrayType.cast(oarray);
+#else[Object]
+            $type$[] array = ($type$[]) oarray;
+#end[Object]
+            return UNSAFE.get$Type$Opaque(array,
+                    (((long) Preconditions.checkIndex(index, array.length, AIOOBE_SUPPLIER)) << handle.ashift) + handle.abase);
+        }
+
+        @ForceInline
+        static void setOpaque(VarHandle ob, Object oarray, int index, $type$ value) {
+            Array handle = (Array)ob;
+#if[Object]
+            Object[] array = (Object[]) handle.arrayType.cast(oarray);
+#else[Object]
+            $type$[] array = ($type$[]) oarray;
+#end[Object]
+            UNSAFE.put$Type$Opaque(array,
+                    (((long) Preconditions.checkIndex(index, array.length, AIOOBE_SUPPLIER)) << handle.ashift) + handle.abase,
+                    {#if[Object]?runtimeTypeCheck(handle, array, value):value});
+        }
+
+        @ForceInline
+        static $type$ getAcquire(VarHandle ob, Object oarray, int index) {
+            Array handle = (Array)ob;
+#if[Object]
+            Object[] array = (Object[]) handle.arrayType.cast(oarray);
+#else[Object]
+            $type$[] array = ($type$[]) oarray;
+#end[Object]
+            return UNSAFE.get$Type$Acquire(array,
+                    (((long) Preconditions.checkIndex(index, array.length, AIOOBE_SUPPLIER)) << handle.ashift) + handle.abase);
+        }
+
+        @ForceInline
+        static void setRelease(VarHandle ob, Object oarray, int index, $type$ value) {
+            Array handle = (Array)ob;
+#if[Object]
+            Object[] array = (Object[]) handle.arrayType.cast(oarray);
+#else[Object]
+            $type$[] array = ($type$[]) oarray;
+#end[Object]
+            UNSAFE.put$Type$Release(array,
+                    (((long) Preconditions.checkIndex(index, array.length, AIOOBE_SUPPLIER)) << handle.ashift) + handle.abase,
+                    {#if[Object]?runtimeTypeCheck(handle, array, value):value});
+        }
+#if[CAS]
+
+        @ForceInline
+        static boolean compareAndSet(VarHandle ob, Object oarray, int index, $type$ expected, $type$ value) {
+            Array handle = (Array)ob;
+#if[Object]
+            Object[] array = (Object[]) handle.arrayType.cast(oarray);
+#else[Object]
+            $type$[] array = ($type$[]) oarray;
+#end[Object]
+            return UNSAFE.compareAndSet$Type$(array,
+                    (((long) Preconditions.checkIndex(index, array.length, AIOOBE_SUPPLIER)) << handle.ashift) + handle.abase,
+                    {#if[Object]?handle.componentType.cast(expected):expected},
+                    {#if[Object]?runtimeTypeCheck(handle, array, value):value});
+        }
+
+        @ForceInline
+        static $type$ compareAndExchange(VarHandle ob, Object oarray, int index, $type$ expected, $type$ value) {
+            Array handle = (Array)ob;
+#if[Object]
+            Object[] array = (Object[]) handle.arrayType.cast(oarray);
+#else[Object]
+            $type$[] array = ($type$[]) oarray;
+#end[Object]
+            return UNSAFE.compareAndExchange$Type$(array,
+                    (((long) Preconditions.checkIndex(index, array.length, AIOOBE_SUPPLIER)) << handle.ashift) + handle.abase,
+                    {#if[Object]?handle.componentType.cast(expected):expected},
+                    {#if[Object]?runtimeTypeCheck(handle, array, value):value});
+        }
+
+        @ForceInline
+        static $type$ compareAndExchangeAcquire(VarHandle ob, Object oarray, int index, $type$ expected, $type$ value) {
+            Array handle = (Array)ob;
+#if[Object]
+            Object[] array = (Object[]) handle.arrayType.cast(oarray);
+#else[Object]
+            $type$[] array = ($type$[]) oarray;
+#end[Object]
+            return UNSAFE.compareAndExchange$Type$Acquire(array,
+                    (((long) Preconditions.checkIndex(index, array.length, AIOOBE_SUPPLIER)) << handle.ashift) + handle.abase,
+                    {#if[Object]?handle.componentType.cast(expected):expected},
+                    {#if[Object]?runtimeTypeCheck(handle, array, value):value});
+        }
+
+        @ForceInline
+        static $type$ compareAndExchangeRelease(VarHandle ob, Object oarray, int index, $type$ expected, $type$ value) {
+            Array handle = (Array)ob;
+#if[Object]
+            Object[] array = (Object[]) handle.arrayType.cast(oarray);
+#else[Object]
+            $type$[] array = ($type$[]) oarray;
+#end[Object]
+            return UNSAFE.compareAndExchange$Type$Release(array,
+                    (((long) Preconditions.checkIndex(index, array.length, AIOOBE_SUPPLIER)) << handle.ashift) + handle.abase,
+                    {#if[Object]?handle.componentType.cast(expected):expected},
+                    {#if[Object]?runtimeTypeCheck(handle, array, value):value});
+        }
+
+        @ForceInline
+        static boolean weakCompareAndSetPlain(VarHandle ob, Object oarray, int index, $type$ expected, $type$ value) {
+            Array handle = (Array)ob;
+#if[Object]
+            Object[] array = (Object[]) handle.arrayType.cast(oarray);
+#else[Object]
+            $type$[] array = ($type$[]) oarray;
+#end[Object]
+            return UNSAFE.weakCompareAndSet$Type$Plain(array,
+                    (((long) Preconditions.checkIndex(index, array.length, AIOOBE_SUPPLIER)) << handle.ashift) + handle.abase,
+                    {#if[Object]?handle.componentType.cast(expected):expected},
+                    {#if[Object]?runtimeTypeCheck(handle, array, value):value});
+        }
+
+        @ForceInline
+        static boolean weakCompareAndSet(VarHandle ob, Object oarray, int index, $type$ expected, $type$ value) {
+            Array handle = (Array)ob;
+#if[Object]
+            Object[] array = (Object[]) handle.arrayType.cast(oarray);
+#else[Object]
+            $type$[] array = ($type$[]) oarray;
+#end[Object]
+            return UNSAFE.weakCompareAndSet$Type$(array,
+                    (((long) Preconditions.checkIndex(index, array.length, AIOOBE_SUPPLIER)) << handle.ashift) + handle.abase,
+                    {#if[Object]?handle.componentType.cast(expected):expected},
+                    {#if[Object]?runtimeTypeCheck(handle, array, value):value});
+        }
+
+        @ForceInline
+        static boolean weakCompareAndSetAcquire(VarHandle ob, Object oarray, int index, $type$ expected, $type$ value) {
+            Array handle = (Array)ob;
+#if[Object]
+            Object[] array = (Object[]) handle.arrayType.cast(oarray);
+#else[Object]
+            $type$[] array = ($type$[]) oarray;
+#end[Object]
+            return UNSAFE.weakCompareAndSet$Type$Acquire(array,
+                    (((long) Preconditions.checkIndex(index, array.length, AIOOBE_SUPPLIER)) << handle.ashift) + handle.abase,
+                    {#if[Object]?handle.componentType.cast(expected):expected},
+                    {#if[Object]?runtimeTypeCheck(handle, array, value):value});
+        }
+
+        @ForceInline
+        static boolean weakCompareAndSetRelease(VarHandle ob, Object oarray, int index, $type$ expected, $type$ value) {
+            Array handle = (Array)ob;
+#if[Object]
+            Object[] array = (Object[]) handle.arrayType.cast(oarray);
+#else[Object]
+            $type$[] array = ($type$[]) oarray;
+#end[Object]
+            return UNSAFE.weakCompareAndSet$Type$Release(array,
+                    (((long) Preconditions.checkIndex(index, array.length, AIOOBE_SUPPLIER)) << handle.ashift) + handle.abase,
+                    {#if[Object]?handle.componentType.cast(expected):expected},
+                    {#if[Object]?runtimeTypeCheck(handle, array, value):value});
+        }
+
+        @ForceInline
+        static $type$ getAndSet(VarHandle ob, Object oarray, int index, $type$ value) {
+            Array handle = (Array)ob;
+#if[Object]
+            Object[] array = (Object[]) handle.arrayType.cast(oarray);
+#else[Object]
+            $type$[] array = ($type$[]) oarray;
+#end[Object]
+            return UNSAFE.getAndSet$Type$(array,
+                    (((long) Preconditions.checkIndex(index, array.length, AIOOBE_SUPPLIER)) << handle.ashift) + handle.abase,
+                    {#if[Object]?runtimeTypeCheck(handle, array, value):value});
+        }
+
+        @ForceInline
+        static $type$ getAndSetAcquire(VarHandle ob, Object oarray, int index, $type$ value) {
+            Array handle = (Array)ob;
+#if[Object]
+            Object[] array = (Object[]) handle.arrayType.cast(oarray);
+#else[Object]
+            $type$[] array = ($type$[]) oarray;
+#end[Object]
+            return UNSAFE.getAndSet$Type$Acquire(array,
+                    (((long) Preconditions.checkIndex(index, array.length, AIOOBE_SUPPLIER)) << handle.ashift) + handle.abase,
+                    {#if[Object]?runtimeTypeCheck(handle, array, value):value});
+        }
+
+        @ForceInline
+        static $type$ getAndSetRelease(VarHandle ob, Object oarray, int index, $type$ value) {
+            Array handle = (Array)ob;
+#if[Object]
+            Object[] array = (Object[]) handle.arrayType.cast(oarray);
+#else[Object]
+            $type$[] array = ($type$[]) oarray;
+#end[Object]
+            return UNSAFE.getAndSet$Type$Release(array,
+                    (((long) Preconditions.checkIndex(index, array.length, AIOOBE_SUPPLIER)) << handle.ashift) + handle.abase,
+                    {#if[Object]?runtimeTypeCheck(handle, array, value):value});
+        }
+#end[CAS]
+#if[AtomicAdd]
+
+        @ForceInline
+        static $type$ getAndAdd(VarHandle ob, Object oarray, int index, $type$ value) {
+            Array handle = (Array)ob;
+            $type$[] array = ($type$[]) oarray;
+            return UNSAFE.getAndAdd$Type$(array,
+                    (((long) Preconditions.checkIndex(index, array.length, AIOOBE_SUPPLIER)) << handle.ashift) + handle.abase,
+                    value);
+        }
+
+        @ForceInline
+        static $type$ getAndAddAcquire(VarHandle ob, Object oarray, int index, $type$ value) {
+            Array handle = (Array)ob;
+            $type$[] array = ($type$[]) oarray;
+            return UNSAFE.getAndAdd$Type$Acquire(array,
+                    (((long) Preconditions.checkIndex(index, array.length, AIOOBE_SUPPLIER)) << handle.ashift) + handle.abase,
+                    value);
+        }
+
+        @ForceInline
+        static $type$ getAndAddRelease(VarHandle ob, Object oarray, int index, $type$ value) {
+            Array handle = (Array)ob;
+            $type$[] array = ($type$[]) oarray;
+            return UNSAFE.getAndAdd$Type$Release(array,
+                    (((long) Preconditions.checkIndex(index, array.length, AIOOBE_SUPPLIER)) << handle.ashift) + handle.abase,
+                    value);
+        }
+#end[AtomicAdd]
+#if[Bitwise]
+
+        @ForceInline
+        static $type$ getAndBitwiseOr(VarHandle ob, Object oarray, int index, $type$ value) {
+            Array handle = (Array)ob;
+            $type$[] array = ($type$[]) oarray;
+            return UNSAFE.getAndBitwiseOr$Type$(array,
+                                       (((long) Preconditions.checkIndex(index, array.length, AIOOBE_SUPPLIER)) << handle.ashift) + handle.abase,
+                                       value);
+        }
+
+        @ForceInline
+        static $type$ getAndBitwiseOrRelease(VarHandle ob, Object oarray, int index, $type$ value) {
+            Array handle = (Array)ob;
+            $type$[] array = ($type$[]) oarray;
+            return UNSAFE.getAndBitwiseOr$Type$Release(array,
+                                       (((long) Preconditions.checkIndex(index, array.length, AIOOBE_SUPPLIER)) << handle.ashift) + handle.abase,
+                                       value);
+        }
+
+        @ForceInline
+        static $type$ getAndBitwiseOrAcquire(VarHandle ob, Object oarray, int index, $type$ value) {
+            Array handle = (Array)ob;
+            $type$[] array = ($type$[]) oarray;
+            return UNSAFE.getAndBitwiseOr$Type$Acquire(array,
+                                       (((long) Preconditions.checkIndex(index, array.length, AIOOBE_SUPPLIER)) << handle.ashift) + handle.abase,
+                                       value);
+        }
+
+        @ForceInline
+        static $type$ getAndBitwiseAnd(VarHandle ob, Object oarray, int index, $type$ value) {
+            Array handle = (Array)ob;
+            $type$[] array = ($type$[]) oarray;
+            return UNSAFE.getAndBitwiseAnd$Type$(array,
+                                       (((long) Preconditions.checkIndex(index, array.length, AIOOBE_SUPPLIER)) << handle.ashift) + handle.abase,
+                                       value);
+        }
+
+        @ForceInline
+        static $type$ getAndBitwiseAndRelease(VarHandle ob, Object oarray, int index, $type$ value) {
+            Array handle = (Array)ob;
+            $type$[] array = ($type$[]) oarray;
+            return UNSAFE.getAndBitwiseAnd$Type$Release(array,
+                                       (((long) Preconditions.checkIndex(index, array.length, AIOOBE_SUPPLIER)) << handle.ashift) + handle.abase,
+                                       value);
+        }
+
+        @ForceInline
+        static $type$ getAndBitwiseAndAcquire(VarHandle ob, Object oarray, int index, $type$ value) {
+            Array handle = (Array)ob;
+            $type$[] array = ($type$[]) oarray;
+            return UNSAFE.getAndBitwiseAnd$Type$Acquire(array,
+                                       (((long) Preconditions.checkIndex(index, array.length, AIOOBE_SUPPLIER)) << handle.ashift) + handle.abase,
+                                       value);
+        }
+
+        @ForceInline
+        static $type$ getAndBitwiseXor(VarHandle ob, Object oarray, int index, $type$ value) {
+            Array handle = (Array)ob;
+            $type$[] array = ($type$[]) oarray;
+            return UNSAFE.getAndBitwiseXor$Type$(array,
+                                       (((long) Preconditions.checkIndex(index, array.length, AIOOBE_SUPPLIER)) << handle.ashift) + handle.abase,
+                                       value);
+        }
+
+        @ForceInline
+        static $type$ getAndBitwiseXorRelease(VarHandle ob, Object oarray, int index, $type$ value) {
+            Array handle = (Array)ob;
+            $type$[] array = ($type$[]) oarray;
+            return UNSAFE.getAndBitwiseXor$Type$Release(array,
+                                       (((long) Preconditions.checkIndex(index, array.length, AIOOBE_SUPPLIER)) << handle.ashift) + handle.abase,
+                                       value);
+        }
+
+        @ForceInline
+        static $type$ getAndBitwiseXorAcquire(VarHandle ob, Object oarray, int index, $type$ value) {
+            Array handle = (Array)ob;
+            $type$[] array = ($type$[]) oarray;
+            return UNSAFE.getAndBitwiseXor$Type$Acquire(array,
+                                       (((long) Preconditions.checkIndex(index, array.length, AIOOBE_SUPPLIER)) << handle.ashift) + handle.abase,
+                                       value);
+        }
+#end[Bitwise]
+
+        static final VarForm FORM = new VarForm(Array.class, {#if[Object]?Object[].class:$type$[].class}, {#if[Object]?Object.class:$type$.class}, int.class);
+    }
+}

--- a/java.base/src/main/java/java/lang/invoke/X-VarHandle.java.template
+++ b/java.base/src/main/java/java/lang/invoke/X-VarHandle.java.template
@@ -100,11 +100,21 @@ final class VarHandle$Type$s {
                                  handle.fieldOffset);
         }
 
+        // @Override
+        public $type$ get(Object holder) {
+            return UNSAFE.get$Type$(Objects.requireNonNull(receiverType.cast(holder)), fieldOffset);
+        }
+
         @ForceInline
         static $type$ getVolatile(VarHandle ob, Object holder) {
             FieldInstanceReadOnly handle = (FieldInstanceReadOnly)ob;
             return UNSAFE.get$Type$Volatile(Objects.requireNonNull(handle.receiverType.cast(holder)),
                                  handle.fieldOffset);
+        }
+
+        // @Override
+        public $type$ getVolatile(Object holder) {
+            return UNSAFE.get$Type$Volatile(Objects.requireNonNull(receiverType.cast(holder)), fieldOffset);
         }
 
         @ForceInline
@@ -114,11 +124,21 @@ final class VarHandle$Type$s {
                                  handle.fieldOffset);
         }
 
+        // @Override
+        public $type$ getOpaque(Object holder) {
+            return UNSAFE.get$Type$Opaque(Objects.requireNonNull(receiverType.cast(holder)), fieldOffset);
+        }
+
         @ForceInline
         static $type$ getAcquire(VarHandle ob, Object holder) {
             FieldInstanceReadOnly handle = (FieldInstanceReadOnly)ob;
             return UNSAFE.get$Type$Acquire(Objects.requireNonNull(handle.receiverType.cast(holder)),
                                  handle.fieldOffset);
+        }
+
+        // @Override
+        public $type$ getAcquire(Object holder) {
+            return UNSAFE.get$Type$Acquire(Objects.requireNonNull(receiverType.cast(holder)), fieldOffset);
         }
 
         static final VarForm FORM = new VarForm(FieldInstanceReadOnly.class, Object.class, $type$.class);
@@ -157,12 +177,24 @@ final class VarHandle$Type$s {
                              {#if[Object]?handle.fieldType.cast(value):value});
         }
 
+        // @Override
+        public void set(Object holder, $type$ value) {
+            UNSAFE.put$Type$(Objects.requireNonNull(receiverType.cast(holder)), fieldOffset,
+                             {#if[Object]?fieldType.cast(value):value});
+        }
+
         @ForceInline
         static void setVolatile(VarHandle ob, Object holder, $type$ value) {
             FieldInstanceReadWrite handle = (FieldInstanceReadWrite)ob;
             UNSAFE.put$Type$Volatile(Objects.requireNonNull(handle.receiverType.cast(holder)),
                                      handle.fieldOffset,
                                      {#if[Object]?handle.fieldType.cast(value):value});
+        }
+
+        // @Override
+        public void setVolatile(Object holder, $type$ value) {
+            UNSAFE.put$Type$Volatile(Objects.requireNonNull(receiverType.cast(holder)), fieldOffset,
+                                     {#if[Object]?fieldType.cast(value):value});
         }
 
         @ForceInline
@@ -173,12 +205,24 @@ final class VarHandle$Type$s {
                                    {#if[Object]?handle.fieldType.cast(value):value});
         }
 
+        // @Override
+        public void setOpaque(Object holder, $type$ value) {
+            UNSAFE.put$Type$Opaque(Objects.requireNonNull(receiverType.cast(holder)), fieldOffset,
+                                   {#if[Object]?fieldType.cast(value):value});
+        }
+
         @ForceInline
         static void setRelease(VarHandle ob, Object holder, $type$ value) {
             FieldInstanceReadWrite handle = (FieldInstanceReadWrite)ob;
             UNSAFE.put$Type$Release(Objects.requireNonNull(handle.receiverType.cast(holder)),
                                     handle.fieldOffset,
                                     {#if[Object]?handle.fieldType.cast(value):value});
+        }
+
+        // @Override
+        public void setRelease(Object holder, $type$ value) {
+            UNSAFE.put$Type$Release(Objects.requireNonNull(receiverType.cast(holder)), fieldOffset,
+                                   {#if[Object]?fieldType.cast(value):value});
         }
 #if[CAS]
 
@@ -191,6 +235,14 @@ final class VarHandle$Type$s {
                                                {#if[Object]?handle.fieldType.cast(value):value});
         }
 
+        // @Override
+        public boolean compareAndSet(Object holder, $type$ expected, $type$ value) {
+            return UNSAFE.compareAndSet$Type$(Objects.requireNonNull(receiverType.cast(holder)),
+                                              fieldOffset,
+                                              {#if[Object]?fieldType.cast(expected):expected},
+                                              {#if[Object]?fieldType.cast(value):value});
+        }
+
         @ForceInline
         static $type$ compareAndExchange(VarHandle ob, Object holder, $type$ expected, $type$ value) {
             FieldInstanceReadWrite handle = (FieldInstanceReadWrite)ob;
@@ -198,6 +250,14 @@ final class VarHandle$Type$s {
                                                handle.fieldOffset,
                                                {#if[Object]?handle.fieldType.cast(expected):expected},
                                                {#if[Object]?handle.fieldType.cast(value):value});
+        }
+
+        // @Override
+        public $type$ compareAndExchange(Object holder, $type$ expected, $type$ value) {
+            return UNSAFE.compareAndExchange$Type$(Objects.requireNonNull(receiverType.cast(holder)),
+                                               fieldOffset,
+                                               {#if[Object]?fieldType.cast(expected):expected},
+                                               {#if[Object]?fieldType.cast(value):value});
         }
 
         @ForceInline
@@ -209,6 +269,14 @@ final class VarHandle$Type$s {
                                                {#if[Object]?handle.fieldType.cast(value):value});
         }
 
+        // @Override
+        public $type$ compareAndExchangeAcquire(Object holder, $type$ expected, $type$ value) {
+            return UNSAFE.compareAndExchange$Type$Acquire(Objects.requireNonNull(receiverType.cast(holder)),
+                                               fieldOffset,
+                                               {#if[Object]?fieldType.cast(expected):expected},
+                                               {#if[Object]?fieldType.cast(value):value});
+        }
+
         @ForceInline
         static $type$ compareAndExchangeRelease(VarHandle ob, Object holder, $type$ expected, $type$ value) {
             FieldInstanceReadWrite handle = (FieldInstanceReadWrite)ob;
@@ -216,6 +284,14 @@ final class VarHandle$Type$s {
                                                handle.fieldOffset,
                                                {#if[Object]?handle.fieldType.cast(expected):expected},
                                                {#if[Object]?handle.fieldType.cast(value):value});
+        }
+
+        // @Override
+        public $type$ compareAndExchangeRelease(Object holder, $type$ expected, $type$ value) {
+            return UNSAFE.compareAndExchange$Type$Release(Objects.requireNonNull(receiverType.cast(holder)),
+                                                          fieldOffset,
+                                                          {#if[Object]?fieldType.cast(expected):expected},
+                                                          {#if[Object]?fieldType.cast(value):value});
         }
 
         @ForceInline
@@ -227,6 +303,14 @@ final class VarHandle$Type$s {
                                                {#if[Object]?handle.fieldType.cast(value):value});
         }
 
+        // @Override
+        public boolean weakCompareAndSetPlain(Object holder, $type$ expected, $type$ value) {
+            return UNSAFE.weakCompareAndSet$Type$Plain(Objects.requireNonNull(receiverType.cast(holder)),
+                                                       fieldOffset,
+                                                       {#if[Object]?fieldType.cast(expected):expected},
+                                                       {#if[Object]?fieldType.cast(value):value});
+        }
+
         @ForceInline
         static boolean weakCompareAndSet(VarHandle ob, Object holder, $type$ expected, $type$ value) {
             FieldInstanceReadWrite handle = (FieldInstanceReadWrite)ob;
@@ -234,6 +318,14 @@ final class VarHandle$Type$s {
                                                handle.fieldOffset,
                                                {#if[Object]?handle.fieldType.cast(expected):expected},
                                                {#if[Object]?handle.fieldType.cast(value):value});
+        }
+
+        // @Override
+        public boolean weakCompareAndSet(Object holder, $type$ expected, $type$ value) {
+            return UNSAFE.weakCompareAndSet$Type$(Objects.requireNonNull(receiverType.cast(holder)),
+                                                  fieldOffset,
+                                                  {#if[Object]?fieldType.cast(expected):expected},
+                                                  {#if[Object]?fieldType.cast(value):value});
         }
 
         @ForceInline
@@ -245,6 +337,14 @@ final class VarHandle$Type$s {
                                                {#if[Object]?handle.fieldType.cast(value):value});
         }
 
+        // @Override
+        public boolean weakCompareAndSetAcquire(Object holder, $type$ expected, $type$ value) {
+            return UNSAFE.weakCompareAndSet$Type$Acquire(Objects.requireNonNull(receiverType.cast(holder)),
+                                                         fieldOffset,
+                                                         {#if[Object]?fieldType.cast(expected):expected},
+                                                         {#if[Object]?fieldType.cast(value):value});
+        }
+
         @ForceInline
         static boolean weakCompareAndSetRelease(VarHandle ob, Object holder, $type$ expected, $type$ value) {
             FieldInstanceReadWrite handle = (FieldInstanceReadWrite)ob;
@@ -252,6 +352,14 @@ final class VarHandle$Type$s {
                                                handle.fieldOffset,
                                                {#if[Object]?handle.fieldType.cast(expected):expected},
                                                {#if[Object]?handle.fieldType.cast(value):value});
+        }
+
+        // @Override
+        public boolean weakCompareAndSetRelease(Object holder, $type$ expected, $type$ value) {
+            return UNSAFE.weakCompareAndSet$Type$Release(Objects.requireNonNull(receiverType.cast(holder)),
+                                                         fieldOffset,
+                                                         {#if[Object]?fieldType.cast(expected):expected},
+                                                         {#if[Object]?fieldType.cast(value):value});
         }
 
         @ForceInline
@@ -262,6 +370,12 @@ final class VarHandle$Type$s {
                                           {#if[Object]?handle.fieldType.cast(value):value});
         }
 
+        // @Override
+        public $type$ getAndSet(Object holder, $type$ value) {
+            return UNSAFE.getAndSet$Type$(Objects.requireNonNull(receiverType.cast(holder)), fieldOffset,
+                                          {#if[Object]?fieldType.cast(value):value});
+        }
+
         @ForceInline
         static $type$ getAndSetAcquire(VarHandle ob, Object holder, $type$ value) {
             FieldInstanceReadWrite handle = (FieldInstanceReadWrite)ob;
@@ -270,12 +384,24 @@ final class VarHandle$Type$s {
                                           {#if[Object]?handle.fieldType.cast(value):value});
         }
 
+        // @Override
+        public $type$ getAndSetAcquire(Object holder, $type$ value) {
+            return UNSAFE.getAndSet$Type$Acquire(Objects.requireNonNull(receiverType.cast(holder)), fieldOffset,
+                                                 {#if[Object]?fieldType.cast(value):value});
+        }
+
         @ForceInline
         static $type$ getAndSetRelease(VarHandle ob, Object holder, $type$ value) {
             FieldInstanceReadWrite handle = (FieldInstanceReadWrite)ob;
             return UNSAFE.getAndSet$Type$Release(Objects.requireNonNull(handle.receiverType.cast(holder)),
                                           handle.fieldOffset,
                                           {#if[Object]?handle.fieldType.cast(value):value});
+        }
+
+        // @Override
+        public $type$ getAndSetRelease(Object holder, $type$ value) {
+            return UNSAFE.getAndSet$Type$Release(Objects.requireNonNull(receiverType.cast(holder)), fieldOffset,
+                                          {#if[Object]?fieldType.cast(value):value});
         }
 #end[CAS]
 #if[AtomicAdd]
@@ -288,12 +414,22 @@ final class VarHandle$Type$s {
                                        value);
         }
 
+        // @Override
+        public $type$ getAndAdd(Object holder, $type$ value) {
+            return UNSAFE.getAndAdd$Type$(Objects.requireNonNull(receiverType.cast(holder)), fieldOffset, value);
+        }
+
         @ForceInline
         static $type$ getAndAddAcquire(VarHandle ob, Object holder, $type$ value) {
             FieldInstanceReadWrite handle = (FieldInstanceReadWrite)ob;
             return UNSAFE.getAndAdd$Type$Acquire(Objects.requireNonNull(handle.receiverType.cast(holder)),
                                        handle.fieldOffset,
                                        value);
+        }
+
+        // @Override
+        public $type$ getAndAddAcquire(Object holder, $type$ value) {
+            return UNSAFE.getAndAdd$Type$Acquire(Objects.requireNonNull(receiverType.cast(holder)), fieldOffset, value);
         }
 
         @ForceInline
@@ -304,6 +440,10 @@ final class VarHandle$Type$s {
                                        value);
         }
 
+        // @Override
+        public $type$ getAndAddRelease(Object holder, $type$ value) {
+            return UNSAFE.getAndAdd$Type$Release(Objects.requireNonNull(receiverType.cast(holder)), fieldOffset, value);
+        }
 #end[AtomicAdd]
 #if[Bitwise]
 
@@ -315,12 +455,22 @@ final class VarHandle$Type$s {
                                        value);
         }
 
+        // @Override
+        public $type$ getAndBitwiseOr(Object holder, $type$ value) {
+            return UNSAFE.getAndBitwiseOr$Type$(Objects.requireNonNull(receiverType.cast(holder)), fieldOffset, value);
+        }
+
         @ForceInline
         static $type$ getAndBitwiseOrRelease(VarHandle ob, Object holder, $type$ value) {
             FieldInstanceReadWrite handle = (FieldInstanceReadWrite)ob;
             return UNSAFE.getAndBitwiseOr$Type$Release(Objects.requireNonNull(handle.receiverType.cast(holder)),
                                        handle.fieldOffset,
                                        value);
+        }
+
+        // @Override
+        public $type$ getAndBitwiseOrRelease(Object holder, $type$ value) {
+            return UNSAFE.getAndBitwiseOr$Type$Release(Objects.requireNonNull(receiverType.cast(holder)), fieldOffset, value);
         }
 
         @ForceInline
@@ -331,12 +481,22 @@ final class VarHandle$Type$s {
                                        value);
         }
 
+        // @Override
+        public $type$ getAndBitwiseOrAcquire(Object holder, $type$ value) {
+            return UNSAFE.getAndBitwiseOr$Type$Acquire(Objects.requireNonNull(receiverType.cast(holder)), fieldOffset, value);
+        }
+
         @ForceInline
         static $type$ getAndBitwiseAnd(VarHandle ob, Object holder, $type$ value) {
             FieldInstanceReadWrite handle = (FieldInstanceReadWrite)ob;
             return UNSAFE.getAndBitwiseAnd$Type$(Objects.requireNonNull(handle.receiverType.cast(holder)),
                                        handle.fieldOffset,
                                        value);
+        }
+
+        // @Override
+        public $type$ getAndBitwiseAnd(Object holder, $type$ value) {
+            return UNSAFE.getAndBitwiseAnd$Type$(Objects.requireNonNull(receiverType.cast(holder)), fieldOffset, value);
         }
 
         @ForceInline
@@ -347,12 +507,22 @@ final class VarHandle$Type$s {
                                        value);
         }
 
+        // @Override
+        public $type$ getAndBitwiseAndRelease(Object holder, $type$ value) {
+            return UNSAFE.getAndBitwiseAnd$Type$Release(Objects.requireNonNull(receiverType.cast(holder)), fieldOffset, value);
+        }
+
         @ForceInline
         static $type$ getAndBitwiseAndAcquire(VarHandle ob, Object holder, $type$ value) {
             FieldInstanceReadWrite handle = (FieldInstanceReadWrite)ob;
             return UNSAFE.getAndBitwiseAnd$Type$Acquire(Objects.requireNonNull(handle.receiverType.cast(holder)),
                                        handle.fieldOffset,
                                        value);
+        }
+
+        // @Override
+        public $type$ getAndBitwiseAndAcquire(Object holder, $type$ value) {
+            return UNSAFE.getAndBitwiseAnd$Type$Acquire(Objects.requireNonNull(receiverType.cast(holder)), fieldOffset, value);
         }
 
         @ForceInline
@@ -363,6 +533,11 @@ final class VarHandle$Type$s {
                                        value);
         }
 
+        // @Override
+        public $type$ getAndBitwiseXor(Object holder, $type$ value) {
+            return UNSAFE.getAndBitwiseXor$Type$(Objects.requireNonNull(receiverType.cast(holder)), fieldOffset, value);
+        }
+
         @ForceInline
         static $type$ getAndBitwiseXorRelease(VarHandle ob, Object holder, $type$ value) {
             FieldInstanceReadWrite handle = (FieldInstanceReadWrite)ob;
@@ -371,12 +546,22 @@ final class VarHandle$Type$s {
                                        value);
         }
 
+        // @Override
+        public $type$ getAndBitwiseXorRelease(Object holder, $type$ value) {
+            return UNSAFE.getAndBitwiseXor$Type$Release(Objects.requireNonNull(receiverType.cast(holder)), fieldOffset, value);
+        }
+
         @ForceInline
         static $type$ getAndBitwiseXorAcquire(VarHandle ob, Object holder, $type$ value) {
             FieldInstanceReadWrite handle = (FieldInstanceReadWrite)ob;
             return UNSAFE.getAndBitwiseXor$Type$Acquire(Objects.requireNonNull(handle.receiverType.cast(holder)),
                                        handle.fieldOffset,
                                        value);
+        }
+
+        // @Override
+        public $type$ getAndBitwiseXorAcquire(Object holder, $type$ value) {
+            return UNSAFE.getAndBitwiseXor$Type$Acquire(Objects.requireNonNull(receiverType.cast(holder)), fieldOffset, value);
         }
 #end[Bitwise]
 
@@ -446,11 +631,21 @@ final class VarHandle$Type$s {
                                  handle.fieldOffset);
         }
 
+        // @Override
+        public $type$ get() {
+            return UNSAFE.get$Type$(base, fieldOffset);
+        }
+
         @ForceInline
         static $type$ getVolatile(VarHandle ob) {
             FieldStaticReadOnly handle = (FieldStaticReadOnly)ob;
             return UNSAFE.get$Type$Volatile(handle.base,
                                  handle.fieldOffset);
+        }
+
+        // @Override
+        public $type$ getVolatile() {
+            return UNSAFE.get$Type$Volatile(base, fieldOffset);
         }
 
         @ForceInline
@@ -460,11 +655,21 @@ final class VarHandle$Type$s {
                                  handle.fieldOffset);
         }
 
+        // @Override
+        public $type$ getOpaque() {
+            return UNSAFE.get$Type$Opaque(base, fieldOffset);
+        }
+
         @ForceInline
         static $type$ getAcquire(VarHandle ob) {
             FieldStaticReadOnly handle = (FieldStaticReadOnly)ob;
             return UNSAFE.get$Type$Acquire(handle.base,
                                  handle.fieldOffset);
+        }
+
+        // @Override
+        public $type$ getAcquire() {
+            return UNSAFE.get$Type$Acquire(base, fieldOffset);
         }
 
         static final VarForm FORM = new VarForm(FieldStaticReadOnly.class, null, $type$.class);
@@ -503,12 +708,22 @@ final class VarHandle$Type$s {
                              {#if[Object]?handle.fieldType.cast(value):value});
         }
 
+        // @Override
+        public void set($type$ value) {
+            UNSAFE.put$Type$(base, fieldOffset, {#if[Object]?fieldType.cast(value):value});
+        }
+
         @ForceInline
         static void setVolatile(VarHandle ob, $type$ value) {
             FieldStaticReadWrite handle = (FieldStaticReadWrite)ob;
             UNSAFE.put$Type$Volatile(handle.base,
                                      handle.fieldOffset,
                                      {#if[Object]?handle.fieldType.cast(value):value});
+        }
+
+        // @Override
+        public void setVolatile($type$ value) {
+            UNSAFE.put$Type$Volatile(base, fieldOffset, {#if[Object]?fieldType.cast(value):value});
         }
 
         @ForceInline
@@ -519,12 +734,22 @@ final class VarHandle$Type$s {
                                    {#if[Object]?handle.fieldType.cast(value):value});
         }
 
+        // @Override
+        public void setOpaque($type$ value) {
+            UNSAFE.put$Type$Opaque(base, fieldOffset, {#if[Object]?fieldType.cast(value):value});
+        }
+
         @ForceInline
         static void setRelease(VarHandle ob, $type$ value) {
             FieldStaticReadWrite handle = (FieldStaticReadWrite)ob;
             UNSAFE.put$Type$Release(handle.base,
                                     handle.fieldOffset,
                                     {#if[Object]?handle.fieldType.cast(value):value});
+        }
+
+        // @Override
+        public void setRelease($type$ value) {
+            UNSAFE.put$Type$Release(base, fieldOffset, {#if[Object]?fieldType.cast(value):value});
         }
 #if[CAS]
 
@@ -537,6 +762,12 @@ final class VarHandle$Type$s {
                                                {#if[Object]?handle.fieldType.cast(value):value});
         }
 
+        // @Override
+        public boolean compareAndSet($type$ expected, $type$ value) {
+            return UNSAFE.compareAndSet$Type$(base, fieldOffset,
+                                              {#if[Object]?fieldType.cast(expected):expected},
+                                              {#if[Object]?fieldType.cast(value):value});
+        }
 
         @ForceInline
         static $type$ compareAndExchange(VarHandle ob, $type$ expected, $type$ value) {
@@ -545,6 +776,13 @@ final class VarHandle$Type$s {
                                                handle.fieldOffset,
                                                {#if[Object]?handle.fieldType.cast(expected):expected},
                                                {#if[Object]?handle.fieldType.cast(value):value});
+        }
+
+        // @Override
+        public $type$ compareAndExchange($type$ expected, $type$ value) {
+            return UNSAFE.compareAndExchange$Type$(base, fieldOffset,
+                                               {#if[Object]?fieldType.cast(expected):expected},
+                                               {#if[Object]?fieldType.cast(value):value});
         }
 
         @ForceInline
@@ -556,6 +794,13 @@ final class VarHandle$Type$s {
                                                {#if[Object]?handle.fieldType.cast(value):value});
         }
 
+        // @Override
+        public $type$ compareAndExchangeAcquire($type$ expected, $type$ value) {
+            return UNSAFE.compareAndExchange$Type$Acquire(base, fieldOffset,
+                                               {#if[Object]?fieldType.cast(expected):expected},
+                                               {#if[Object]?fieldType.cast(value):value});
+        }
+
         @ForceInline
         static $type$ compareAndExchangeRelease(VarHandle ob, $type$ expected, $type$ value) {
             FieldStaticReadWrite handle = (FieldStaticReadWrite)ob;
@@ -563,6 +808,13 @@ final class VarHandle$Type$s {
                                                handle.fieldOffset,
                                                {#if[Object]?handle.fieldType.cast(expected):expected},
                                                {#if[Object]?handle.fieldType.cast(value):value});
+        }
+
+        // @Override
+        public $type$ compareAndExchangeRelease($type$ expected, $type$ value) {
+            return UNSAFE.compareAndExchange$Type$Release(base, fieldOffset,
+                                               {#if[Object]?fieldType.cast(expected):expected},
+                                               {#if[Object]?fieldType.cast(value):value});
         }
 
         @ForceInline
@@ -574,6 +826,13 @@ final class VarHandle$Type$s {
                                                {#if[Object]?handle.fieldType.cast(value):value});
         }
 
+        // @Override
+        public boolean weakCompareAndSetPlain($type$ expected, $type$ value) {
+            return UNSAFE.weakCompareAndSet$Type$Plain(base, fieldOffset,
+                                                       {#if[Object]?fieldType.cast(expected):expected},
+                                                       {#if[Object]?fieldType.cast(value):value});
+        }
+
         @ForceInline
         static boolean weakCompareAndSet(VarHandle ob, $type$ expected, $type$ value) {
             FieldStaticReadWrite handle = (FieldStaticReadWrite)ob;
@@ -581,6 +840,13 @@ final class VarHandle$Type$s {
                                                handle.fieldOffset,
                                                {#if[Object]?handle.fieldType.cast(expected):expected},
                                                {#if[Object]?handle.fieldType.cast(value):value});
+        }
+
+        // @Override
+        public boolean weakCompareAndSet($type$ expected, $type$ value) {
+            return UNSAFE.weakCompareAndSet$Type$(base, fieldOffset,
+                                                  {#if[Object]?fieldType.cast(expected):expected},
+                                                  {#if[Object]?fieldType.cast(value):value});
         }
 
         @ForceInline
@@ -592,6 +858,13 @@ final class VarHandle$Type$s {
                                                {#if[Object]?handle.fieldType.cast(value):value});
         }
 
+        // @Override
+        public boolean weakCompareAndSetAcquire($type$ expected, $type$ value) {
+            return UNSAFE.weakCompareAndSet$Type$Acquire(base, fieldOffset,
+                                                         {#if[Object]?fieldType.cast(expected):expected},
+                                                         {#if[Object]?fieldType.cast(value):value});
+        }
+
         @ForceInline
         static boolean weakCompareAndSetRelease(VarHandle ob, $type$ expected, $type$ value) {
             FieldStaticReadWrite handle = (FieldStaticReadWrite)ob;
@@ -599,6 +872,13 @@ final class VarHandle$Type$s {
                                                handle.fieldOffset,
                                                {#if[Object]?handle.fieldType.cast(expected):expected},
                                                {#if[Object]?handle.fieldType.cast(value):value});
+        }
+
+        // @Override
+        public boolean weakCompareAndSetRelease($type$ expected, $type$ value) {
+            return UNSAFE.weakCompareAndSet$Type$Release(base, fieldOffset,
+                                                         {#if[Object]?fieldType.cast(expected):expected},
+                                                         {#if[Object]?fieldType.cast(value):value});
         }
 
         @ForceInline
@@ -609,6 +889,11 @@ final class VarHandle$Type$s {
                                           {#if[Object]?handle.fieldType.cast(value):value});
         }
 
+        // @Override
+        public $type$ getAndSet($type$ value) {
+            return UNSAFE.getAndSet$Type$(base, fieldOffset, {#if[Object]?fieldType.cast(value):value});
+        }
+
         @ForceInline
         static $type$ getAndSetAcquire(VarHandle ob, $type$ value) {
             FieldStaticReadWrite handle = (FieldStaticReadWrite)ob;
@@ -617,12 +902,22 @@ final class VarHandle$Type$s {
                                           {#if[Object]?handle.fieldType.cast(value):value});
         }
 
+        // @Override
+        public $type$ getAndSetAcquire($type$ value) {
+            return UNSAFE.getAndSet$Type$Acquire(base, fieldOffset, {#if[Object]?fieldType.cast(value):value});
+        }
+
         @ForceInline
         static $type$ getAndSetRelease(VarHandle ob, $type$ value) {
             FieldStaticReadWrite handle = (FieldStaticReadWrite)ob;
             return UNSAFE.getAndSet$Type$Release(handle.base,
                                           handle.fieldOffset,
                                           {#if[Object]?handle.fieldType.cast(value):value});
+        }
+
+        // @Override
+        public $type$ getAndSetRelease($type$ value) {
+            return UNSAFE.getAndSet$Type$Release(base, fieldOffset, {#if[Object]?fieldType.cast(value):value});
         }
 #end[CAS]
 #if[AtomicAdd]
@@ -635,6 +930,11 @@ final class VarHandle$Type$s {
                                        value);
         }
 
+        // @Override
+        public $type$ getAndAdd($type$ value) {
+            return UNSAFE.getAndAdd$Type$(base, fieldOffset, value);
+        }
+
         @ForceInline
         static $type$ getAndAddAcquire(VarHandle ob, $type$ value) {
             FieldStaticReadWrite handle = (FieldStaticReadWrite)ob;
@@ -643,12 +943,22 @@ final class VarHandle$Type$s {
                                        value);
         }
 
+        // @Override
+        public $type$ getAndAddAcquire($type$ value) {
+            return UNSAFE.getAndAdd$Type$Acquire(base, fieldOffset, value);
+        }
+
         @ForceInline
         static $type$ getAndAddRelease(VarHandle ob, $type$ value) {
             FieldStaticReadWrite handle = (FieldStaticReadWrite)ob;
             return UNSAFE.getAndAdd$Type$Release(handle.base,
                                        handle.fieldOffset,
                                        value);
+        }
+
+        // @Override
+        public $type$ getAndAddRelease($type$ value) {
+            return UNSAFE.getAndAdd$Type$Release(base, fieldOffset, value);
         }
 #end[AtomicAdd]
 #if[Bitwise]
@@ -661,12 +971,22 @@ final class VarHandle$Type$s {
                                        value);
         }
 
+        // @Override
+        public $type$ getAndBitwiseOr($type$ value) {
+            return UNSAFE.getAndBitwiseOr$Type$(base, fieldOffset, value);
+        }
+
         @ForceInline
         static $type$ getAndBitwiseOrRelease(VarHandle ob, $type$ value) {
             FieldStaticReadWrite handle = (FieldStaticReadWrite)ob;
             return UNSAFE.getAndBitwiseOr$Type$Release(handle.base,
                                        handle.fieldOffset,
                                        value);
+        }
+
+        // @Override
+        public $type$ getAndBitwiseOrRelease($type$ value) {
+            return UNSAFE.getAndBitwiseOr$Type$Release(base, fieldOffset, value);
         }
 
         @ForceInline
@@ -677,12 +997,22 @@ final class VarHandle$Type$s {
                                        value);
         }
 
+        // @Override
+        public $type$ getAndBitwiseOrAcquire($type$ value) {
+            return UNSAFE.getAndBitwiseOr$Type$Acquire(base, fieldOffset, value);
+        }
+
         @ForceInline
         static $type$ getAndBitwiseAnd(VarHandle ob, $type$ value) {
             FieldStaticReadWrite handle = (FieldStaticReadWrite)ob;
             return UNSAFE.getAndBitwiseAnd$Type$(handle.base,
                                        handle.fieldOffset,
                                        value);
+        }
+
+        // @Override
+        public $type$ getAndBitwiseAnd($type$ value) {
+            return UNSAFE.getAndBitwiseAnd$Type$(base, fieldOffset, value);
         }
 
         @ForceInline
@@ -693,12 +1023,22 @@ final class VarHandle$Type$s {
                                        value);
         }
 
+        // @Override
+        public $type$ getAndBitwiseAndRelease($type$ value) {
+            return UNSAFE.getAndBitwiseAnd$Type$Release(base, fieldOffset, value);
+        }
+
         @ForceInline
         static $type$ getAndBitwiseAndAcquire(VarHandle ob, $type$ value) {
             FieldStaticReadWrite handle = (FieldStaticReadWrite)ob;
             return UNSAFE.getAndBitwiseAnd$Type$Acquire(handle.base,
                                        handle.fieldOffset,
                                        value);
+        }
+
+        // @Override
+        public $type$ getAndBitwiseAndAcquire($type$ value) {
+            return UNSAFE.getAndBitwiseAnd$Type$Acquire(base, fieldOffset, value);
         }
 
         @ForceInline
@@ -709,6 +1049,11 @@ final class VarHandle$Type$s {
                                        value);
         }
 
+        // @Override
+        public $type$ getAndBitwiseXor($type$ value) {
+            return UNSAFE.getAndBitwiseXor$Type$(base, fieldOffset, value);
+        }
+
         @ForceInline
         static $type$ getAndBitwiseXorRelease(VarHandle ob, $type$ value) {
             FieldStaticReadWrite handle = (FieldStaticReadWrite)ob;
@@ -717,12 +1062,22 @@ final class VarHandle$Type$s {
                                        value);
         }
 
+        // @Override
+        public $type$ getAndBitwiseXorRelease($type$ value) {
+            return UNSAFE.getAndBitwiseXor$Type$Release(base, fieldOffset, value);
+        }
+
         @ForceInline
         static $type$ getAndBitwiseXorAcquire(VarHandle ob, $type$ value) {
             FieldStaticReadWrite handle = (FieldStaticReadWrite)ob;
             return UNSAFE.getAndBitwiseXor$Type$Acquire(handle.base,
                                        handle.fieldOffset,
                                        value);
+        }
+
+        // @Override
+        public $type$ getAndBitwiseXorAcquire($type$ value) {
+            return UNSAFE.getAndBitwiseXor$Type$Acquire(base, fieldOffset, value);
         }
 #end[Bitwise]
 
@@ -813,6 +1168,16 @@ final class VarHandle$Type$s {
             return array[index];
         }
 
+        // @Override
+        public $type$ get(Object oarray, int index) {
+#if[Object]
+            Object[] array = (Object[]) arrayType.cast(oarray);
+#else[Object]
+            $type$[] array = ($type$[]) oarray;
+#end[Object]
+            return array[index];
+        }
+
         @ForceInline
         static void set(VarHandle ob, Object oarray, int index, $type$ value) {
             Array handle = (Array)ob;
@@ -822,6 +1187,16 @@ final class VarHandle$Type$s {
             $type$[] array = ($type$[]) oarray;
 #end[Object]
             array[index] = {#if[Object]?handle.componentType.cast(value):value};
+        }
+
+        // @Override
+        public void set(Object oarray, int index, $type$ value) {
+#if[Object]
+            Object[] array = (Object[]) arrayType.cast(oarray);
+#else[Object]
+            $type$[] array = ($type$[]) oarray;
+#end[Object]
+            array[index] = {#if[Object]?componentType.cast(value):value};
         }
 
         @ForceInline
@@ -834,6 +1209,17 @@ final class VarHandle$Type$s {
 #end[Object]
             return UNSAFE.get$Type$Volatile(array,
                     (((long) Preconditions.checkIndex(index, array.length, AIOOBE_SUPPLIER)) << handle.ashift) + handle.abase);
+        }
+
+        // @Override
+        public $type$ getVolatile(Object oarray, int index) {
+#if[Object]
+            Object[] array = (Object[]) arrayType.cast(oarray);
+#else[Object]
+            $type$[] array = ($type$[]) oarray;
+#end[Object]
+            return UNSAFE.get$Type$Volatile(array,
+                    (((long) Preconditions.checkIndex(index, array.length, AIOOBE_SUPPLIER)) << ashift) + abase);
         }
 
         @ForceInline
@@ -849,6 +1235,18 @@ final class VarHandle$Type$s {
                     {#if[Object]?runtimeTypeCheck(handle, array, value):value});
         }
 
+        // @Override
+        public void setVolatile(Object oarray, int index, $type$ value) {
+#if[Object]
+            Object[] array = (Object[]) arrayType.cast(oarray);
+#else[Object]
+            $type$[] array = ($type$[]) oarray;
+#end[Object]
+            UNSAFE.put$Type$Volatile(array,
+                    (((long) Preconditions.checkIndex(index, array.length, AIOOBE_SUPPLIER)) << ashift) + abase,
+                    {#if[Object]?runtimeTypeCheck(this, array, value):value});
+        }
+
         @ForceInline
         static $type$ getOpaque(VarHandle ob, Object oarray, int index) {
             Array handle = (Array)ob;
@@ -859,6 +1257,17 @@ final class VarHandle$Type$s {
 #end[Object]
             return UNSAFE.get$Type$Opaque(array,
                     (((long) Preconditions.checkIndex(index, array.length, AIOOBE_SUPPLIER)) << handle.ashift) + handle.abase);
+        }
+
+        // @Override
+        public $type$ getOpaque(Object oarray, int index) {
+#if[Object]
+            Object[] array = (Object[]) arrayType.cast(oarray);
+#else[Object]
+            $type$[] array = ($type$[]) oarray;
+#end[Object]
+            return UNSAFE.get$Type$Opaque(array,
+                    (((long) Preconditions.checkIndex(index, array.length, AIOOBE_SUPPLIER)) << ashift) + abase);
         }
 
         @ForceInline
@@ -874,6 +1283,18 @@ final class VarHandle$Type$s {
                     {#if[Object]?runtimeTypeCheck(handle, array, value):value});
         }
 
+        // @Override
+        public void setOpaque(Object oarray, int index, $type$ value) {
+#if[Object]
+            Object[] array = (Object[]) arrayType.cast(oarray);
+#else[Object]
+            $type$[] array = ($type$[]) oarray;
+#end[Object]
+            UNSAFE.put$Type$Opaque(array,
+                    (((long) Preconditions.checkIndex(index, array.length, AIOOBE_SUPPLIER)) << ashift) + abase,
+                    {#if[Object]?runtimeTypeCheck(this, array, value):value});
+        }
+
         @ForceInline
         static $type$ getAcquire(VarHandle ob, Object oarray, int index) {
             Array handle = (Array)ob;
@@ -884,6 +1305,17 @@ final class VarHandle$Type$s {
 #end[Object]
             return UNSAFE.get$Type$Acquire(array,
                     (((long) Preconditions.checkIndex(index, array.length, AIOOBE_SUPPLIER)) << handle.ashift) + handle.abase);
+        }
+
+        // @Override
+        public $type$ getAcquire(Object oarray, int index) {
+#if[Object]
+            Object[] array = (Object[]) arrayType.cast(oarray);
+#else[Object]
+            $type$[] array = ($type$[]) oarray;
+#end[Object]
+            return UNSAFE.get$Type$Acquire(array,
+                    (((long) Preconditions.checkIndex(index, array.length, AIOOBE_SUPPLIER)) << ashift) + abase);
         }
 
         @ForceInline
@@ -897,6 +1329,18 @@ final class VarHandle$Type$s {
             UNSAFE.put$Type$Release(array,
                     (((long) Preconditions.checkIndex(index, array.length, AIOOBE_SUPPLIER)) << handle.ashift) + handle.abase,
                     {#if[Object]?runtimeTypeCheck(handle, array, value):value});
+        }
+
+        // @Override
+        public void setRelease(Object oarray, int index, $type$ value) {
+#if[Object]
+            Object[] array = (Object[]) arrayType.cast(oarray);
+#else[Object]
+            $type$[] array = ($type$[]) oarray;
+#end[Object]
+            UNSAFE.put$Type$Release(array,
+                    (((long) Preconditions.checkIndex(index, array.length, AIOOBE_SUPPLIER)) << ashift) + abase,
+                    {#if[Object]?runtimeTypeCheck(this, array, value):value});
         }
 #if[CAS]
 
@@ -914,6 +1358,19 @@ final class VarHandle$Type$s {
                     {#if[Object]?runtimeTypeCheck(handle, array, value):value});
         }
 
+        // @Override
+        public boolean compareAndSet(Object oarray, int index, $type$ expected, $type$ value) {
+#if[Object]
+            Object[] array = (Object[]) arrayType.cast(oarray);
+#else[Object]
+            $type$[] array = ($type$[]) oarray;
+#end[Object]
+            return UNSAFE.compareAndSet$Type$(array,
+                    (((long) Preconditions.checkIndex(index, array.length, AIOOBE_SUPPLIER)) << ashift) + abase,
+                    {#if[Object]?componentType.cast(expected):expected},
+                    {#if[Object]?runtimeTypeCheck(this, array, value):value});
+        }
+
         @ForceInline
         static $type$ compareAndExchange(VarHandle ob, Object oarray, int index, $type$ expected, $type$ value) {
             Array handle = (Array)ob;
@@ -926,6 +1383,19 @@ final class VarHandle$Type$s {
                     (((long) Preconditions.checkIndex(index, array.length, AIOOBE_SUPPLIER)) << handle.ashift) + handle.abase,
                     {#if[Object]?handle.componentType.cast(expected):expected},
                     {#if[Object]?runtimeTypeCheck(handle, array, value):value});
+        }
+
+        // @Override
+        public $type$ compareAndExchange(Object oarray, int index, $type$ expected, $type$ value) {
+#if[Object]
+            Object[] array = (Object[]) arrayType.cast(oarray);
+#else[Object]
+            $type$[] array = ($type$[]) oarray;
+#end[Object]
+            return UNSAFE.compareAndExchange$Type$(array,
+                    (((long) Preconditions.checkIndex(index, array.length, AIOOBE_SUPPLIER)) << ashift) + abase,
+                    {#if[Object]?componentType.cast(expected):expected},
+                    {#if[Object]?runtimeTypeCheck(this, array, value):value});
         }
 
         @ForceInline
@@ -942,6 +1412,19 @@ final class VarHandle$Type$s {
                     {#if[Object]?runtimeTypeCheck(handle, array, value):value});
         }
 
+        // @Override
+        public $type$ compareAndExchangeAcquire(Object oarray, int index, $type$ expected, $type$ value) {
+#if[Object]
+            Object[] array = (Object[]) arrayType.cast(oarray);
+#else[Object]
+            $type$[] array = ($type$[]) oarray;
+#end[Object]
+            return UNSAFE.compareAndExchange$Type$Acquire(array,
+                    (((long) Preconditions.checkIndex(index, array.length, AIOOBE_SUPPLIER)) << ashift) + abase,
+                    {#if[Object]?componentType.cast(expected):expected},
+                    {#if[Object]?runtimeTypeCheck(this, array, value):value});
+        }
+
         @ForceInline
         static $type$ compareAndExchangeRelease(VarHandle ob, Object oarray, int index, $type$ expected, $type$ value) {
             Array handle = (Array)ob;
@@ -954,6 +1437,19 @@ final class VarHandle$Type$s {
                     (((long) Preconditions.checkIndex(index, array.length, AIOOBE_SUPPLIER)) << handle.ashift) + handle.abase,
                     {#if[Object]?handle.componentType.cast(expected):expected},
                     {#if[Object]?runtimeTypeCheck(handle, array, value):value});
+        }
+
+        // @Override
+        public $type$ compareAndExchangeRelease(Object oarray, int index, $type$ expected, $type$ value) {
+#if[Object]
+            Object[] array = (Object[]) arrayType.cast(oarray);
+#else[Object]
+            $type$[] array = ($type$[]) oarray;
+#end[Object]
+            return UNSAFE.compareAndExchange$Type$Release(array,
+                    (((long) Preconditions.checkIndex(index, array.length, AIOOBE_SUPPLIER)) << ashift) + abase,
+                    {#if[Object]?componentType.cast(expected):expected},
+                    {#if[Object]?runtimeTypeCheck(this, array, value):value});
         }
 
         @ForceInline
@@ -970,6 +1466,19 @@ final class VarHandle$Type$s {
                     {#if[Object]?runtimeTypeCheck(handle, array, value):value});
         }
 
+        // @Override
+        public boolean weakCompareAndSetPlain(Object oarray, int index, $type$ expected, $type$ value) {
+#if[Object]
+            Object[] array = (Object[]) arrayType.cast(oarray);
+#else[Object]
+            $type$[] array = ($type$[]) oarray;
+#end[Object]
+            return UNSAFE.weakCompareAndSet$Type$Plain(array,
+                    (((long) Preconditions.checkIndex(index, array.length, AIOOBE_SUPPLIER)) << ashift) + abase,
+                    {#if[Object]?componentType.cast(expected):expected},
+                    {#if[Object]?runtimeTypeCheck(this, array, value):value});
+        }
+
         @ForceInline
         static boolean weakCompareAndSet(VarHandle ob, Object oarray, int index, $type$ expected, $type$ value) {
             Array handle = (Array)ob;
@@ -982,6 +1491,19 @@ final class VarHandle$Type$s {
                     (((long) Preconditions.checkIndex(index, array.length, AIOOBE_SUPPLIER)) << handle.ashift) + handle.abase,
                     {#if[Object]?handle.componentType.cast(expected):expected},
                     {#if[Object]?runtimeTypeCheck(handle, array, value):value});
+        }
+
+        // @Override
+        public boolean weakCompareAndSet(Object oarray, int index, $type$ expected, $type$ value) {
+#if[Object]
+            Object[] array = (Object[]) arrayType.cast(oarray);
+#else[Object]
+            $type$[] array = ($type$[]) oarray;
+#end[Object]
+            return UNSAFE.weakCompareAndSet$Type$(array,
+                    (((long) Preconditions.checkIndex(index, array.length, AIOOBE_SUPPLIER)) << ashift) + abase,
+                    {#if[Object]?componentType.cast(expected):expected},
+                    {#if[Object]?runtimeTypeCheck(this, array, value):value});
         }
 
         @ForceInline
@@ -998,6 +1520,19 @@ final class VarHandle$Type$s {
                     {#if[Object]?runtimeTypeCheck(handle, array, value):value});
         }
 
+        // @Override
+        public boolean weakCompareAndSetAcquire(Object oarray, int index, $type$ expected, $type$ value) {
+#if[Object]
+            Object[] array = (Object[]) arrayType.cast(oarray);
+#else[Object]
+            $type$[] array = ($type$[]) oarray;
+#end[Object]
+            return UNSAFE.weakCompareAndSet$Type$Acquire(array,
+                    (((long) Preconditions.checkIndex(index, array.length, AIOOBE_SUPPLIER)) << ashift) + abase,
+                    {#if[Object]?componentType.cast(expected):expected},
+                    {#if[Object]?runtimeTypeCheck(this, array, value):value});
+        }
+
         @ForceInline
         static boolean weakCompareAndSetRelease(VarHandle ob, Object oarray, int index, $type$ expected, $type$ value) {
             Array handle = (Array)ob;
@@ -1010,6 +1545,19 @@ final class VarHandle$Type$s {
                     (((long) Preconditions.checkIndex(index, array.length, AIOOBE_SUPPLIER)) << handle.ashift) + handle.abase,
                     {#if[Object]?handle.componentType.cast(expected):expected},
                     {#if[Object]?runtimeTypeCheck(handle, array, value):value});
+        }
+
+        // @Override
+        public boolean weakCompareAndSetRelease(Object oarray, int index, $type$ expected, $type$ value) {
+#if[Object]
+            Object[] array = (Object[]) arrayType.cast(oarray);
+#else[Object]
+            $type$[] array = ($type$[]) oarray;
+#end[Object]
+            return UNSAFE.weakCompareAndSet$Type$Release(array,
+                    (((long) Preconditions.checkIndex(index, array.length, AIOOBE_SUPPLIER)) << ashift) + abase,
+                    {#if[Object]?componentType.cast(expected):expected},
+                    {#if[Object]?runtimeTypeCheck(this, array, value):value});
         }
 
         @ForceInline
@@ -1025,6 +1573,18 @@ final class VarHandle$Type$s {
                     {#if[Object]?runtimeTypeCheck(handle, array, value):value});
         }
 
+        // @Override
+        public $type$ getAndSet(Object oarray, int index, $type$ value) {
+#if[Object]
+            Object[] array = (Object[]) arrayType.cast(oarray);
+#else[Object]
+            $type$[] array = ($type$[]) oarray;
+#end[Object]
+            return UNSAFE.getAndSet$Type$(array,
+                    (((long) Preconditions.checkIndex(index, array.length, AIOOBE_SUPPLIER)) << ashift) + abase,
+                    {#if[Object]?runtimeTypeCheck(this, array, value):value});
+        }
+
         @ForceInline
         static $type$ getAndSetAcquire(VarHandle ob, Object oarray, int index, $type$ value) {
             Array handle = (Array)ob;
@@ -1036,6 +1596,18 @@ final class VarHandle$Type$s {
             return UNSAFE.getAndSet$Type$Acquire(array,
                     (((long) Preconditions.checkIndex(index, array.length, AIOOBE_SUPPLIER)) << handle.ashift) + handle.abase,
                     {#if[Object]?runtimeTypeCheck(handle, array, value):value});
+        }
+
+        // @Override
+        public $type$ getAndSetAcquire(Object oarray, int index, $type$ value) {
+#if[Object]
+            Object[] array = (Object[]) arrayType.cast(oarray);
+#else[Object]
+            $type$[] array = ($type$[]) oarray;
+#end[Object]
+            return UNSAFE.getAndSet$Type$Acquire(array,
+                    (((long) Preconditions.checkIndex(index, array.length, AIOOBE_SUPPLIER)) << ashift) + abase,
+                    {#if[Object]?runtimeTypeCheck(this, array, value):value});
         }
 
         @ForceInline
@@ -1050,6 +1622,18 @@ final class VarHandle$Type$s {
                     (((long) Preconditions.checkIndex(index, array.length, AIOOBE_SUPPLIER)) << handle.ashift) + handle.abase,
                     {#if[Object]?runtimeTypeCheck(handle, array, value):value});
         }
+
+        // @Override
+        public $type$ getAndSetRelease(Object oarray, int index, $type$ value) {
+#if[Object]
+            Object[] array = (Object[]) arrayType.cast(oarray);
+#else[Object]
+            $type$[] array = ($type$[]) oarray;
+#end[Object]
+            return UNSAFE.getAndSet$Type$Release(array,
+                    (((long) Preconditions.checkIndex(index, array.length, AIOOBE_SUPPLIER)) << ashift) + abase,
+                    {#if[Object]?runtimeTypeCheck(this, array, value):value});
+        }
 #end[CAS]
 #if[AtomicAdd]
 
@@ -1062,6 +1646,14 @@ final class VarHandle$Type$s {
                     value);
         }
 
+        // @Override
+        public $type$ getAndAdd(Object oarray, int index, $type$ value) {
+            $type$[] array = ($type$[]) oarray;
+            return UNSAFE.getAndAdd$Type$(array,
+                    (((long) Preconditions.checkIndex(index, array.length, AIOOBE_SUPPLIER)) << ashift) + abase,
+                    value);
+        }
+
         @ForceInline
         static $type$ getAndAddAcquire(VarHandle ob, Object oarray, int index, $type$ value) {
             Array handle = (Array)ob;
@@ -1071,12 +1663,28 @@ final class VarHandle$Type$s {
                     value);
         }
 
+        // @Override
+        public $type$ getAndAddAcquire(Object oarray, int index, $type$ value) {
+            $type$[] array = ($type$[]) oarray;
+            return UNSAFE.getAndAdd$Type$Acquire(array,
+                    (((long) Preconditions.checkIndex(index, array.length, AIOOBE_SUPPLIER)) << ashift) + abase,
+                    value);
+        }
+
         @ForceInline
         static $type$ getAndAddRelease(VarHandle ob, Object oarray, int index, $type$ value) {
             Array handle = (Array)ob;
             $type$[] array = ($type$[]) oarray;
             return UNSAFE.getAndAdd$Type$Release(array,
                     (((long) Preconditions.checkIndex(index, array.length, AIOOBE_SUPPLIER)) << handle.ashift) + handle.abase,
+                    value);
+        }
+
+        // @Override
+        public $type$ getAndAddRelease(Object oarray, int index, $type$ value) {
+            $type$[] array = ($type$[]) oarray;
+            return UNSAFE.getAndAdd$Type$Release(array,
+                    (((long) Preconditions.checkIndex(index, array.length, AIOOBE_SUPPLIER)) << ashift) + abase,
                     value);
         }
 #end[AtomicAdd]
@@ -1091,12 +1699,28 @@ final class VarHandle$Type$s {
                                        value);
         }
 
+        // @Override
+        public $type$ getAndBitwiseOr(Object oarray, int index, $type$ value) {
+            $type$[] array = ($type$[]) oarray;
+            return UNSAFE.getAndBitwiseOr$Type$(array,
+                                       (((long) Preconditions.checkIndex(index, array.length, AIOOBE_SUPPLIER)) << ashift) + abase,
+                                       value);
+        }
+
         @ForceInline
         static $type$ getAndBitwiseOrRelease(VarHandle ob, Object oarray, int index, $type$ value) {
             Array handle = (Array)ob;
             $type$[] array = ($type$[]) oarray;
             return UNSAFE.getAndBitwiseOr$Type$Release(array,
                                        (((long) Preconditions.checkIndex(index, array.length, AIOOBE_SUPPLIER)) << handle.ashift) + handle.abase,
+                                       value);
+        }
+
+        // @Override
+        public $type$ getAndBitwiseOrRelease(Object oarray, int index, $type$ value) {
+            $type$[] array = ($type$[]) oarray;
+            return UNSAFE.getAndBitwiseOr$Type$Release(array,
+                                       (((long) Preconditions.checkIndex(index, array.length, AIOOBE_SUPPLIER)) << ashift) + abase,
                                        value);
         }
 
@@ -1109,12 +1733,28 @@ final class VarHandle$Type$s {
                                        value);
         }
 
+        // @Override
+        public $type$ getAndBitwiseOrAcquire(Object oarray, int index, $type$ value) {
+            $type$[] array = ($type$[]) oarray;
+            return UNSAFE.getAndBitwiseOr$Type$Acquire(array,
+                                       (((long) Preconditions.checkIndex(index, array.length, AIOOBE_SUPPLIER)) << ashift) + abase,
+                                       value);
+        }
+
         @ForceInline
         static $type$ getAndBitwiseAnd(VarHandle ob, Object oarray, int index, $type$ value) {
             Array handle = (Array)ob;
             $type$[] array = ($type$[]) oarray;
             return UNSAFE.getAndBitwiseAnd$Type$(array,
                                        (((long) Preconditions.checkIndex(index, array.length, AIOOBE_SUPPLIER)) << handle.ashift) + handle.abase,
+                                       value);
+        }
+
+        // @Override
+        public $type$ getAndBitwiseAnd(Object oarray, int index, $type$ value) {
+            $type$[] array = ($type$[]) oarray;
+            return UNSAFE.getAndBitwiseAnd$Type$(array,
+                                       (((long) Preconditions.checkIndex(index, array.length, AIOOBE_SUPPLIER)) << ashift) + abase,
                                        value);
         }
 
@@ -1127,12 +1767,28 @@ final class VarHandle$Type$s {
                                        value);
         }
 
+        // @Override
+        public $type$ getAndBitwiseAndRelease(Object oarray, int index, $type$ value) {
+            $type$[] array = ($type$[]) oarray;
+            return UNSAFE.getAndBitwiseAnd$Type$Release(array,
+                                       (((long) Preconditions.checkIndex(index, array.length, AIOOBE_SUPPLIER)) << ashift) + abase,
+                                       value);
+        }
+
         @ForceInline
         static $type$ getAndBitwiseAndAcquire(VarHandle ob, Object oarray, int index, $type$ value) {
             Array handle = (Array)ob;
             $type$[] array = ($type$[]) oarray;
             return UNSAFE.getAndBitwiseAnd$Type$Acquire(array,
                                        (((long) Preconditions.checkIndex(index, array.length, AIOOBE_SUPPLIER)) << handle.ashift) + handle.abase,
+                                       value);
+        }
+
+        // @Override
+        public $type$ getAndBitwiseAndAcquire(Object oarray, int index, $type$ value) {
+            $type$[] array = ($type$[]) oarray;
+            return UNSAFE.getAndBitwiseAnd$Type$Acquire(array,
+                                       (((long) Preconditions.checkIndex(index, array.length, AIOOBE_SUPPLIER)) << ashift) + abase,
                                        value);
         }
 
@@ -1145,6 +1801,14 @@ final class VarHandle$Type$s {
                                        value);
         }
 
+        // @Override
+        public $type$ getAndBitwiseXor(Object oarray, int index, $type$ value) {
+            $type$[] array = ($type$[]) oarray;
+            return UNSAFE.getAndBitwiseXor$Type$(array,
+                                       (((long) Preconditions.checkIndex(index, array.length, AIOOBE_SUPPLIER)) << ashift) + abase,
+                                       value);
+        }
+
         @ForceInline
         static $type$ getAndBitwiseXorRelease(VarHandle ob, Object oarray, int index, $type$ value) {
             Array handle = (Array)ob;
@@ -1154,12 +1818,28 @@ final class VarHandle$Type$s {
                                        value);
         }
 
+        // @Override
+        public $type$ getAndBitwiseXorRelease(Object oarray, int index, $type$ value) {
+            $type$[] array = ($type$[]) oarray;
+            return UNSAFE.getAndBitwiseXor$Type$Release(array,
+                                       (((long) Preconditions.checkIndex(index, array.length, AIOOBE_SUPPLIER)) << ashift) + abase,
+                                       value);
+        }
+
         @ForceInline
         static $type$ getAndBitwiseXorAcquire(VarHandle ob, Object oarray, int index, $type$ value) {
             Array handle = (Array)ob;
             $type$[] array = ($type$[]) oarray;
             return UNSAFE.getAndBitwiseXor$Type$Acquire(array,
                                        (((long) Preconditions.checkIndex(index, array.length, AIOOBE_SUPPLIER)) << handle.ashift) + handle.abase,
+                                       value);
+        }
+
+        // @Override
+        public $type$ getAndBitwiseXorAcquire(Object oarray, int index, $type$ value) {
+            $type$[] array = ($type$[]) oarray;
+            return UNSAFE.getAndBitwiseXor$Type$Acquire(array,
+                                       (((long) Preconditions.checkIndex(index, array.length, AIOOBE_SUPPLIER)) << ashift) + abase,
                                        value);
         }
 #end[Bitwise]

--- a/java.base/src/main/java/java/lang/invoke/X-VarHandle.java.template
+++ b/java.base/src/main/java/java/lang/invoke/X-VarHandle.java.template
@@ -31,10 +31,13 @@ import java.lang.invoke.VarHandle.VarHandleDesc;
 import java.util.Objects;
 import java.util.Optional;
 
+import org.qbicc.rt.annotation.Tracking;
+
 import static java.lang.invoke.MethodHandleStatics.UNSAFE;
 
 #warn
 
+@Tracking("src/java.base/share/classes/java/lang/invoke/X-VarHandle.java.template")
 final class VarHandle$Type$s {
 
     static class FieldInstanceReadOnly extends VarHandle {

--- a/java.base/src/main/java/java/lang/invoke/X-VarHandleByteArrayView.java.template
+++ b/java.base/src/main/java/java/lang/invoke/X-VarHandleByteArrayView.java.template
@@ -1,0 +1,1096 @@
+/*
+ * Copyright (c) 2015, 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package java.lang.invoke;
+
+import jdk.internal.access.JavaNioAccess;
+import jdk.internal.access.SharedSecrets;
+import jdk.internal.access.foreign.MemorySegmentProxy;
+import jdk.internal.misc.ScopedMemoryAccess;
+import jdk.internal.misc.ScopedMemoryAccess.Scope;
+import jdk.internal.misc.Unsafe;
+import jdk.internal.util.Preconditions;
+import jdk.internal.vm.annotation.ForceInline;
+
+import java.nio.ByteBuffer;
+import java.nio.ReadOnlyBufferException;
+import java.util.List;
+import java.util.Objects;
+import java.util.function.BiFunction;
+
+import static java.lang.invoke.MethodHandleStatics.UNSAFE;
+
+#warn
+
+final class VarHandleByteArrayAs$Type$s extends VarHandleByteArrayBase {
+
+    static final JavaNioAccess NIO_ACCESS = SharedSecrets.getJavaNioAccess();
+
+    static final int ALIGN = $BoxType$.BYTES - 1;
+    
+    static final ScopedMemoryAccess SCOPED_MEMORY_ACCESS = ScopedMemoryAccess.getScopedMemoryAccess();
+
+#if[floatingPoint]
+    @ForceInline
+    static $rawType$ convEndian(boolean big, $type$ v) {
+        $rawType$ rv = $Type$.$type$ToRaw$RawType$Bits(v);
+        return big == BE ? rv : $RawBoxType$.reverseBytes(rv);
+    }
+
+    @ForceInline
+    static $type$ convEndian(boolean big, $rawType$ rv) {
+        rv = big == BE ? rv : $RawBoxType$.reverseBytes(rv);
+        return $Type$.$rawType$BitsTo$Type$(rv);
+    }
+#else[floatingPoint]
+    @ForceInline
+    static $type$ convEndian(boolean big, $type$ n) {
+        return big == BE ? n : $BoxType$.reverseBytes(n);
+    }
+#end[floatingPoint]
+
+
+    private static abstract class ByteArrayViewVarHandle extends VarHandle {
+        final boolean be;
+
+        ByteArrayViewVarHandle(VarForm form, boolean be, boolean exact) {
+            super(form, exact);
+            this.be = be;
+        }
+    }
+
+    static final class ArrayHandle extends ByteArrayViewVarHandle {
+
+        ArrayHandle(boolean be) {
+            this(be, false);
+        }
+
+        private ArrayHandle(boolean be, boolean exact) {
+            super(ArrayHandle.FORM, be, exact);
+        }
+
+        @Override
+        public ArrayHandle withInvokeExactBehavior() {
+            return hasInvokeExactBehavior()
+                ? this
+                : new ArrayHandle(be, true);
+        }
+
+        @Override
+        public ArrayHandle withInvokeBehavior() {
+            return !hasInvokeExactBehavior()
+                ? this
+                : new ArrayHandle(be, false);
+        }
+
+        @Override
+        final MethodType accessModeTypeUncached(AccessType at) {
+            return at.accessModeType(byte[].class, $type$.class, int.class);
+        }
+
+        private static final BiFunction<String, List<Number>, ArrayIndexOutOfBoundsException>
+            OOBEF = Preconditions.outOfBoundsExceptionFormatter(ArrayIndexOutOfBoundsException::new);
+
+        @ForceInline
+        static int index(byte[] ba, int index) {
+            return Preconditions.checkIndex(index, ba.length - ALIGN, OOBEF);
+        }
+
+        @ForceInline
+        static long address(byte[] ba, int index) {
+            long address = ((long) index) + Unsafe.ARRAY_BYTE_BASE_OFFSET;
+            if ((address & ALIGN) != 0)
+                throw newIllegalStateExceptionForMisalignedAccess(index);
+            return address;
+        }
+
+        @ForceInline
+        static $type$ get(VarHandle ob, Object oba, int index) {
+            ArrayHandle handle = (ArrayHandle)ob;
+            byte[] ba = (byte[]) oba;
+#if[floatingPoint]
+            $rawType$ rawValue = UNSAFE.get$RawType$Unaligned(
+                    ba,
+                    ((long) index(ba, index)) + Unsafe.ARRAY_BYTE_BASE_OFFSET,
+                    handle.be);
+            return $Type$.$rawType$BitsTo$Type$(rawValue);
+#else[floatingPoint]
+            return UNSAFE.get$Type$Unaligned(
+                    ba,
+                    ((long) index(ba, index)) + Unsafe.ARRAY_BYTE_BASE_OFFSET,
+                    handle.be);
+#end[floatingPoint]
+        }
+
+        @ForceInline
+        static void set(VarHandle ob, Object oba, int index, $type$ value) {
+            ArrayHandle handle = (ArrayHandle)ob;
+            byte[] ba = (byte[]) oba;
+#if[floatingPoint]
+            UNSAFE.put$RawType$Unaligned(
+                    ba,
+                    ((long) index(ba, index)) + Unsafe.ARRAY_BYTE_BASE_OFFSET,
+                    $Type$.$type$ToRaw$RawType$Bits(value),
+                    handle.be);
+#else[floatingPoint]
+            UNSAFE.put$RawType$Unaligned(
+                    ba,
+                    ((long) index(ba, index)) + Unsafe.ARRAY_BYTE_BASE_OFFSET,
+                    value,
+                    handle.be);
+#end[floatingPoint]
+        }
+
+        @ForceInline
+        static $type$ getVolatile(VarHandle ob, Object oba, int index) {
+            ArrayHandle handle = (ArrayHandle)ob;
+            byte[] ba = (byte[]) oba;
+            return convEndian(handle.be,
+                              UNSAFE.get$RawType$Volatile(
+                                      ba,
+                                      address(ba, index(ba, index))));
+        }
+
+        @ForceInline
+        static void setVolatile(VarHandle ob, Object oba, int index, $type$ value) {
+            ArrayHandle handle = (ArrayHandle)ob;
+            byte[] ba = (byte[]) oba;
+            UNSAFE.put$RawType$Volatile(
+                    ba,
+                    address(ba, index(ba, index)),
+                    convEndian(handle.be, value));
+        }
+
+        @ForceInline
+        static $type$ getAcquire(VarHandle ob, Object oba, int index) {
+            ArrayHandle handle = (ArrayHandle)ob;
+            byte[] ba = (byte[]) oba;
+            return convEndian(handle.be,
+                              UNSAFE.get$RawType$Acquire(
+                                      ba,
+                                      address(ba, index(ba, index))));
+        }
+
+        @ForceInline
+        static void setRelease(VarHandle ob, Object oba, int index, $type$ value) {
+            ArrayHandle handle = (ArrayHandle)ob;
+            byte[] ba = (byte[]) oba;
+            UNSAFE.put$RawType$Release(
+                    ba,
+                    address(ba, index(ba, index)),
+                    convEndian(handle.be, value));
+        }
+
+        @ForceInline
+        static $type$ getOpaque(VarHandle ob, Object oba, int index) {
+            ArrayHandle handle = (ArrayHandle)ob;
+            byte[] ba = (byte[]) oba;
+            return convEndian(handle.be,
+                              UNSAFE.get$RawType$Opaque(
+                                      ba,
+                                      address(ba, index(ba, index))));
+        }
+
+        @ForceInline
+        static void setOpaque(VarHandle ob, Object oba, int index, $type$ value) {
+            ArrayHandle handle = (ArrayHandle)ob;
+            byte[] ba = (byte[]) oba;
+            UNSAFE.put$RawType$Opaque(
+                    ba,
+                    address(ba, index(ba, index)),
+                    convEndian(handle.be, value));
+        }
+#if[CAS]
+
+        @ForceInline
+        static boolean compareAndSet(VarHandle ob, Object oba, int index, $type$ expected, $type$ value) {
+            ArrayHandle handle = (ArrayHandle)ob;
+            byte[] ba = (byte[]) oba;
+#if[Object]
+            return UNSAFE.compareAndSetReference(
+                    ba,
+                    address(ba, index(ba, index)),
+                    convEndian(handle.be, expected), convEndian(handle.be, value));
+#else[Object]
+            return UNSAFE.compareAndSet$RawType$(
+                    ba,
+                    address(ba, index(ba, index)),
+                    convEndian(handle.be, expected), convEndian(handle.be, value));
+#end[Object]
+        }
+
+        @ForceInline
+        static $type$ compareAndExchange(VarHandle ob, Object oba, int index, $type$ expected, $type$ value) {
+            ArrayHandle handle = (ArrayHandle)ob;
+            byte[] ba = (byte[]) oba;
+            return convEndian(handle.be,
+                              UNSAFE.compareAndExchange$RawType$(
+                                      ba,
+                                      address(ba, index(ba, index)),
+                                      convEndian(handle.be, expected), convEndian(handle.be, value)));
+        }
+
+        @ForceInline
+        static $type$ compareAndExchangeAcquire(VarHandle ob, Object oba, int index, $type$ expected, $type$ value) {
+            ArrayHandle handle = (ArrayHandle)ob;
+            byte[] ba = (byte[]) oba;
+            return convEndian(handle.be,
+                              UNSAFE.compareAndExchange$RawType$Acquire(
+                                      ba,
+                                      address(ba, index(ba, index)),
+                                      convEndian(handle.be, expected), convEndian(handle.be, value)));
+        }
+
+        @ForceInline
+        static $type$ compareAndExchangeRelease(VarHandle ob, Object oba, int index, $type$ expected, $type$ value) {
+            ArrayHandle handle = (ArrayHandle)ob;
+            byte[] ba = (byte[]) oba;
+            return convEndian(handle.be,
+                              UNSAFE.compareAndExchange$RawType$Release(
+                                      ba,
+                                      address(ba, index(ba, index)),
+                                      convEndian(handle.be, expected), convEndian(handle.be, value)));
+        }
+
+        @ForceInline
+        static boolean weakCompareAndSetPlain(VarHandle ob, Object oba, int index, $type$ expected, $type$ value) {
+            ArrayHandle handle = (ArrayHandle)ob;
+            byte[] ba = (byte[]) oba;
+            return UNSAFE.weakCompareAndSet$RawType$Plain(
+                    ba,
+                    address(ba, index(ba, index)),
+                    convEndian(handle.be, expected), convEndian(handle.be, value));
+        }
+
+        @ForceInline
+        static boolean weakCompareAndSet(VarHandle ob, Object oba, int index, $type$ expected, $type$ value) {
+            ArrayHandle handle = (ArrayHandle)ob;
+            byte[] ba = (byte[]) oba;
+            return UNSAFE.weakCompareAndSet$RawType$(
+                    ba,
+                    address(ba, index(ba, index)),
+                    convEndian(handle.be, expected), convEndian(handle.be, value));
+        }
+
+        @ForceInline
+        static boolean weakCompareAndSetAcquire(VarHandle ob, Object oba, int index, $type$ expected, $type$ value) {
+            ArrayHandle handle = (ArrayHandle)ob;
+            byte[] ba = (byte[]) oba;
+            return UNSAFE.weakCompareAndSet$RawType$Acquire(
+                    ba,
+                    address(ba, index(ba, index)),
+                    convEndian(handle.be, expected), convEndian(handle.be, value));
+        }
+
+        @ForceInline
+        static boolean weakCompareAndSetRelease(VarHandle ob, Object oba, int index, $type$ expected, $type$ value) {
+            ArrayHandle handle = (ArrayHandle)ob;
+            byte[] ba = (byte[]) oba;
+            return UNSAFE.weakCompareAndSet$RawType$Release(
+                    ba,
+                    address(ba, index(ba, index)),
+                    convEndian(handle.be, expected), convEndian(handle.be, value));
+        }
+
+        @ForceInline
+        static $type$ getAndSet(VarHandle ob, Object oba, int index, $type$ value) {
+            ArrayHandle handle = (ArrayHandle)ob;
+            byte[] ba = (byte[]) oba;
+#if[Object]
+            return convEndian(handle.be,
+                              UNSAFE.getAndSetReference(
+                                      ba,
+                                      address(ba, index(ba, index)),
+                                      convEndian(handle.be, value)));
+#else[Object]
+            return convEndian(handle.be,
+                              UNSAFE.getAndSet$RawType$(
+                                      ba,
+                                      address(ba, index(ba, index)),
+                                      convEndian(handle.be, value)));
+#end[Object]
+        }
+
+        @ForceInline
+        static $type$ getAndSetAcquire(VarHandle ob, Object oba, int index, $type$ value) {
+            ArrayHandle handle = (ArrayHandle)ob;
+            byte[] ba = (byte[]) oba;
+            return convEndian(handle.be,
+                              UNSAFE.getAndSet$RawType$Acquire(
+                                      ba,
+                                      address(ba, index(ba, index)),
+                                      convEndian(handle.be, value)));
+        }
+
+        @ForceInline
+        static $type$ getAndSetRelease(VarHandle ob, Object oba, int index, $type$ value) {
+            ArrayHandle handle = (ArrayHandle)ob;
+            byte[] ba = (byte[]) oba;
+            return convEndian(handle.be,
+                              UNSAFE.getAndSet$RawType$Release(
+                                      ba,
+                                      address(ba, index(ba, index)),
+                                      convEndian(handle.be, value)));
+        }
+#end[CAS]
+#if[AtomicAdd]
+
+        @ForceInline
+        static $type$ getAndAdd(VarHandle ob, Object oba, int index, $type$ delta) {
+            ArrayHandle handle = (ArrayHandle)ob;
+            byte[] ba = (byte[]) oba;
+            if (handle.be == BE) {
+                return UNSAFE.getAndAdd$RawType$(
+                        ba,
+                        address(ba, index(ba, index)),
+                        delta);
+            } else {
+                return getAndAddConvEndianWithCAS(ba, index, delta);
+            }
+        }
+
+        @ForceInline
+        static $type$ getAndAddAcquire(VarHandle ob, Object oba, int index, $type$ delta) {
+            ArrayHandle handle = (ArrayHandle)ob;
+            byte[] ba = (byte[]) oba;
+            if (handle.be == BE) {
+                return UNSAFE.getAndAdd$RawType$Acquire(
+                        ba,
+                        address(ba, index(ba, index)),
+                        delta);
+            } else {
+                return getAndAddConvEndianWithCAS(ba, index, delta);
+            }
+        }
+
+        @ForceInline
+        static $type$ getAndAddRelease(VarHandle ob, Object oba, int index, $type$ delta) {
+            ArrayHandle handle = (ArrayHandle)ob;
+            byte[] ba = (byte[]) oba;
+            if (handle.be == BE) {
+                return UNSAFE.getAndAdd$RawType$Release(
+                        ba,
+                        address(ba, index(ba, index)),
+                        delta);
+            } else {
+                return getAndAddConvEndianWithCAS(ba, index, delta);
+            }
+        }
+
+        @ForceInline
+        static $type$ getAndAddConvEndianWithCAS(byte[] ba, int index, $type$ delta) {
+            $type$ nativeExpectedValue, expectedValue;
+            long offset = address(ba, index(ba, index));
+            do {
+                nativeExpectedValue = UNSAFE.get$RawType$Volatile(ba, offset);
+                expectedValue = $RawBoxType$.reverseBytes(nativeExpectedValue);
+            } while (!UNSAFE.weakCompareAndSet$RawType$(ba, offset,
+                    nativeExpectedValue, $RawBoxType$.reverseBytes(expectedValue + delta)));
+            return expectedValue;
+        }
+#end[AtomicAdd]
+#if[Bitwise]
+
+        @ForceInline
+        static $type$ getAndBitwiseOr(VarHandle ob, Object oba, int index, $type$ value) {
+            ArrayHandle handle = (ArrayHandle)ob;
+            byte[] ba = (byte[]) oba;
+            if (handle.be == BE) {
+                return UNSAFE.getAndBitwiseOr$RawType$(
+                        ba,
+                        address(ba, index(ba, index)),
+                        value);
+            } else {
+                return getAndBitwiseOrConvEndianWithCAS(ba, index, value);
+            }
+        }
+
+        @ForceInline
+        static $type$ getAndBitwiseOrRelease(VarHandle ob, Object oba, int index, $type$ value) {
+            ArrayHandle handle = (ArrayHandle)ob;
+            byte[] ba = (byte[]) oba;
+            if (handle.be == BE) {
+                return UNSAFE.getAndBitwiseOr$RawType$Release(
+                        ba,
+                        address(ba, index(ba, index)),
+                        value);
+            } else {
+                return getAndBitwiseOrConvEndianWithCAS(ba, index, value);
+            }
+        }
+
+        @ForceInline
+        static $type$ getAndBitwiseOrAcquire(VarHandle ob, Object oba, int index, $type$ value) {
+            ArrayHandle handle = (ArrayHandle)ob;
+            byte[] ba = (byte[]) oba;
+            if (handle.be == BE) {
+                return UNSAFE.getAndBitwiseOr$RawType$Acquire(
+                        ba,
+                        address(ba, index(ba, index)),
+                        value);
+            } else {
+                return getAndBitwiseOrConvEndianWithCAS(ba, index, value);
+            }
+        }
+
+        @ForceInline
+        static $type$ getAndBitwiseOrConvEndianWithCAS(byte[] ba, int index, $type$ value) {
+            $type$ nativeExpectedValue, expectedValue;
+            long offset = address(ba, index(ba, index));
+            do {
+                nativeExpectedValue = UNSAFE.get$RawType$Volatile(ba, offset);
+                expectedValue = $RawBoxType$.reverseBytes(nativeExpectedValue);
+            } while (!UNSAFE.weakCompareAndSet$RawType$(ba, offset,
+                    nativeExpectedValue, $RawBoxType$.reverseBytes(expectedValue | value)));
+            return expectedValue;
+        }
+
+        @ForceInline
+        static $type$ getAndBitwiseAnd(VarHandle ob, Object oba, int index, $type$ value) {
+            ArrayHandle handle = (ArrayHandle)ob;
+            byte[] ba = (byte[]) oba;
+            if (handle.be == BE) {
+                return UNSAFE.getAndBitwiseAnd$RawType$(
+                        ba,
+                        address(ba, index(ba, index)),
+                        value);
+            } else {
+                return getAndBitwiseAndConvEndianWithCAS(ba, index, value);
+            }
+        }
+
+        @ForceInline
+        static $type$ getAndBitwiseAndRelease(VarHandle ob, Object oba, int index, $type$ value) {
+            ArrayHandle handle = (ArrayHandle)ob;
+            byte[] ba = (byte[]) oba;
+            if (handle.be == BE) {
+                return UNSAFE.getAndBitwiseAnd$RawType$Release(
+                        ba,
+                        address(ba, index(ba, index)),
+                        value);
+            } else {
+                return getAndBitwiseAndConvEndianWithCAS(ba, index, value);
+            }
+        }
+
+        @ForceInline
+        static $type$ getAndBitwiseAndAcquire(VarHandle ob, Object oba, int index, $type$ value) {
+            ArrayHandle handle = (ArrayHandle)ob;
+            byte[] ba = (byte[]) oba;
+            if (handle.be == BE) {
+                return UNSAFE.getAndBitwiseAnd$RawType$Acquire(
+                        ba,
+                        address(ba, index(ba, index)),
+                        value);
+            } else {
+                return getAndBitwiseAndConvEndianWithCAS(ba, index, value);
+            }
+        }
+
+        @ForceInline
+        static $type$ getAndBitwiseAndConvEndianWithCAS(byte[] ba, int index, $type$ value) {
+            $type$ nativeExpectedValue, expectedValue;
+            long offset = address(ba, index(ba, index));
+            do {
+                nativeExpectedValue = UNSAFE.get$RawType$Volatile(ba, offset);
+                expectedValue = $RawBoxType$.reverseBytes(nativeExpectedValue);
+            } while (!UNSAFE.weakCompareAndSet$RawType$(ba, offset,
+                    nativeExpectedValue, $RawBoxType$.reverseBytes(expectedValue & value)));
+            return expectedValue;
+        }
+
+        @ForceInline
+        static $type$ getAndBitwiseXor(VarHandle ob, Object oba, int index, $type$ value) {
+            ArrayHandle handle = (ArrayHandle)ob;
+            byte[] ba = (byte[]) oba;
+            if (handle.be == BE) {
+                return UNSAFE.getAndBitwiseXor$RawType$(
+                        ba,
+                        address(ba, index(ba, index)),
+                        value);
+            } else {
+                return getAndBitwiseXorConvEndianWithCAS(ba, index, value);
+            }
+        }
+
+        @ForceInline
+        static $type$ getAndBitwiseXorRelease(VarHandle ob, Object oba, int index, $type$ value) {
+            ArrayHandle handle = (ArrayHandle)ob;
+            byte[] ba = (byte[]) oba;
+            if (handle.be == BE) {
+                return UNSAFE.getAndBitwiseXor$RawType$Release(
+                        ba,
+                        address(ba, index(ba, index)),
+                        value);
+            } else {
+                return getAndBitwiseXorConvEndianWithCAS(ba, index, value);
+            }
+        }
+
+        @ForceInline
+        static $type$ getAndBitwiseXorAcquire(VarHandle ob, Object oba, int index, $type$ value) {
+            ArrayHandle handle = (ArrayHandle)ob;
+            byte[] ba = (byte[]) oba;
+            if (handle.be == BE) {
+                return UNSAFE.getAndBitwiseXor$RawType$Acquire(
+                        ba,
+                        address(ba, index(ba, index)),
+                        value);
+            } else {
+                return getAndBitwiseXorConvEndianWithCAS(ba, index, value);
+            }
+        }
+
+        @ForceInline
+        static $type$ getAndBitwiseXorConvEndianWithCAS(byte[] ba, int index, $type$ value) {
+            $type$ nativeExpectedValue, expectedValue;
+            long offset = address(ba, index(ba, index));
+            do {
+                nativeExpectedValue = UNSAFE.get$RawType$Volatile(ba, offset);
+                expectedValue = $RawBoxType$.reverseBytes(nativeExpectedValue);
+            } while (!UNSAFE.weakCompareAndSet$RawType$(ba, offset,
+                    nativeExpectedValue, $RawBoxType$.reverseBytes(expectedValue ^ value)));
+            return expectedValue;
+        }
+#end[Bitwise]
+
+        static final VarForm FORM = new VarForm(ArrayHandle.class, byte[].class, $type$.class, int.class);
+    }
+
+
+    static final class ByteBufferHandle extends ByteArrayViewVarHandle {
+
+        ByteBufferHandle(boolean be) {
+            this(be, false);
+        }
+
+        private ByteBufferHandle(boolean be, boolean exact) {
+            super(ByteBufferHandle.FORM, be, exact);
+        }
+
+        @Override
+        public ByteBufferHandle withInvokeExactBehavior() {
+            return hasInvokeExactBehavior()
+                ? this
+                : new ByteBufferHandle(be, true);
+        }
+
+        @Override
+        public ByteBufferHandle withInvokeBehavior() {
+            return !hasInvokeExactBehavior()
+                ? this
+                : new ByteBufferHandle(be, false);
+        }
+
+        @Override
+        final MethodType accessModeTypeUncached(AccessType at) {
+            return at.accessModeType(ByteBuffer.class, $type$.class, int.class);
+        }
+
+        @ForceInline
+        static int index(ByteBuffer bb, int index) {
+            MemorySegmentProxy segmentProxy = NIO_ACCESS.bufferSegment(bb);
+            return Preconditions.checkIndex(index, UNSAFE.getInt(bb, BUFFER_LIMIT) - ALIGN, null);
+        }
+
+        @ForceInline
+        static Scope scope(ByteBuffer bb) {
+            MemorySegmentProxy segmentProxy = NIO_ACCESS.bufferSegment(bb);
+            return segmentProxy != null ?
+                    segmentProxy.scope() : null;
+        }
+
+        @ForceInline
+        static int indexRO(ByteBuffer bb, int index) {
+            if (UNSAFE.getBoolean(bb, BYTE_BUFFER_IS_READ_ONLY))
+                throw new ReadOnlyBufferException();
+            return index(bb, index);
+        }
+
+        @ForceInline
+        static long address(ByteBuffer bb, int index) {
+            long address = ((long) index) + UNSAFE.getLong(bb, BUFFER_ADDRESS);
+            if ((address & ALIGN) != 0)
+                throw newIllegalStateExceptionForMisalignedAccess(index);
+            return address;
+        }
+
+        @ForceInline
+        static $type$ get(VarHandle ob, Object obb, int index) {
+            ByteBufferHandle handle = (ByteBufferHandle)ob;
+            ByteBuffer bb = (ByteBuffer) Objects.requireNonNull(obb);
+#if[floatingPoint]
+            $rawType$ rawValue = SCOPED_MEMORY_ACCESS.get$RawType$Unaligned(scope(bb),
+                    UNSAFE.getReference(bb, BYTE_BUFFER_HB),
+                    ((long) index(bb, index)) + UNSAFE.getLong(bb, BUFFER_ADDRESS),
+                    handle.be);
+            return $Type$.$rawType$BitsTo$Type$(rawValue);
+#else[floatingPoint]
+            return SCOPED_MEMORY_ACCESS.get$Type$Unaligned(scope(bb),
+                    UNSAFE.getReference(bb, BYTE_BUFFER_HB),
+                    ((long) index(bb, index)) + UNSAFE.getLong(bb, BUFFER_ADDRESS),
+                    handle.be);
+#end[floatingPoint]
+        }
+
+        @ForceInline
+        static void set(VarHandle ob, Object obb, int index, $type$ value) {
+            ByteBufferHandle handle = (ByteBufferHandle)ob;
+            ByteBuffer bb = (ByteBuffer) Objects.requireNonNull(obb);
+#if[floatingPoint]
+            SCOPED_MEMORY_ACCESS.put$RawType$Unaligned(scope(bb),
+                    UNSAFE.getReference(bb, BYTE_BUFFER_HB),
+                    ((long) indexRO(bb, index)) + UNSAFE.getLong(bb, BUFFER_ADDRESS),
+                    $Type$.$type$ToRaw$RawType$Bits(value),
+                    handle.be);
+#else[floatingPoint]
+            SCOPED_MEMORY_ACCESS.put$Type$Unaligned(scope(bb),
+                    UNSAFE.getReference(bb, BYTE_BUFFER_HB),
+                    ((long) indexRO(bb, index)) + UNSAFE.getLong(bb, BUFFER_ADDRESS),
+                    value,
+                    handle.be);
+#end[floatingPoint]
+        }
+
+        @ForceInline
+        static $type$ getVolatile(VarHandle ob, Object obb, int index) {
+            ByteBufferHandle handle = (ByteBufferHandle)ob;
+            ByteBuffer bb = (ByteBuffer) Objects.requireNonNull(obb);
+            return convEndian(handle.be,
+                              SCOPED_MEMORY_ACCESS.get$RawType$Volatile(scope(bb),
+                                      UNSAFE.getReference(bb, BYTE_BUFFER_HB),
+                                      address(bb, index(bb, index))));
+        }
+
+        @ForceInline
+        static void setVolatile(VarHandle ob, Object obb, int index, $type$ value) {
+            ByteBufferHandle handle = (ByteBufferHandle)ob;
+            ByteBuffer bb = (ByteBuffer) Objects.requireNonNull(obb);
+            SCOPED_MEMORY_ACCESS.put$RawType$Volatile(scope(bb),
+                    UNSAFE.getReference(bb, BYTE_BUFFER_HB),
+                    address(bb, indexRO(bb, index)),
+                    convEndian(handle.be, value));
+        }
+
+        @ForceInline
+        static $type$ getAcquire(VarHandle ob, Object obb, int index) {
+            ByteBufferHandle handle = (ByteBufferHandle)ob;
+            ByteBuffer bb = (ByteBuffer) Objects.requireNonNull(obb);
+            return convEndian(handle.be,
+                              SCOPED_MEMORY_ACCESS.get$RawType$Acquire(scope(bb),
+                                      UNSAFE.getReference(bb, BYTE_BUFFER_HB),
+                                      address(bb, index(bb, index))));
+        }
+
+        @ForceInline
+        static void setRelease(VarHandle ob, Object obb, int index, $type$ value) {
+            ByteBufferHandle handle = (ByteBufferHandle)ob;
+            ByteBuffer bb = (ByteBuffer) Objects.requireNonNull(obb);
+            SCOPED_MEMORY_ACCESS.put$RawType$Release(scope(bb),
+                    UNSAFE.getReference(bb, BYTE_BUFFER_HB),
+                    address(bb, indexRO(bb, index)),
+                    convEndian(handle.be, value));
+        }
+
+        @ForceInline
+        static $type$ getOpaque(VarHandle ob, Object obb, int index) {
+            ByteBufferHandle handle = (ByteBufferHandle)ob;
+            ByteBuffer bb = (ByteBuffer) Objects.requireNonNull(obb);
+            return convEndian(handle.be,
+                              SCOPED_MEMORY_ACCESS.get$RawType$Opaque(scope(bb),
+                                      UNSAFE.getReference(bb, BYTE_BUFFER_HB),
+                                      address(bb, index(bb, index))));
+        }
+
+        @ForceInline
+        static void setOpaque(VarHandle ob, Object obb, int index, $type$ value) {
+            ByteBufferHandle handle = (ByteBufferHandle)ob;
+            ByteBuffer bb = (ByteBuffer) Objects.requireNonNull(obb);
+            SCOPED_MEMORY_ACCESS.put$RawType$Opaque(scope(bb),
+                    UNSAFE.getReference(bb, BYTE_BUFFER_HB),
+                    address(bb, indexRO(bb, index)),
+                    convEndian(handle.be, value));
+        }
+#if[CAS]
+
+        @ForceInline
+        static boolean compareAndSet(VarHandle ob, Object obb, int index, $type$ expected, $type$ value) {
+            ByteBufferHandle handle = (ByteBufferHandle)ob;
+            ByteBuffer bb = (ByteBuffer) Objects.requireNonNull(obb);
+#if[Object]
+            return SCOPED_MEMORY_ACCESS.compareAndSetReference(scope(bb),
+                    UNSAFE.getReference(bb, BYTE_BUFFER_HB),
+                    address(bb, indexRO(bb, index)),
+                    convEndian(handle.be, expected), convEndian(handle.be, value));
+#else[Object]
+            return SCOPED_MEMORY_ACCESS.compareAndSet$RawType$(scope(bb),
+                    UNSAFE.getReference(bb, BYTE_BUFFER_HB),
+                    address(bb, indexRO(bb, index)),
+                    convEndian(handle.be, expected), convEndian(handle.be, value));
+#end[Object]
+        }
+
+        @ForceInline
+        static $type$ compareAndExchange(VarHandle ob, Object obb, int index, $type$ expected, $type$ value) {
+            ByteBufferHandle handle = (ByteBufferHandle)ob;
+            ByteBuffer bb = (ByteBuffer) Objects.requireNonNull(obb);
+            return convEndian(handle.be,
+                              SCOPED_MEMORY_ACCESS.compareAndExchange$RawType$(scope(bb),
+                                      UNSAFE.getReference(bb, BYTE_BUFFER_HB),
+                                      address(bb, indexRO(bb, index)),
+                                      convEndian(handle.be, expected), convEndian(handle.be, value)));
+        }
+
+        @ForceInline
+        static $type$ compareAndExchangeAcquire(VarHandle ob, Object obb, int index, $type$ expected, $type$ value) {
+            ByteBufferHandle handle = (ByteBufferHandle)ob;
+            ByteBuffer bb = (ByteBuffer) Objects.requireNonNull(obb);
+            return convEndian(handle.be,
+                              SCOPED_MEMORY_ACCESS.compareAndExchange$RawType$Acquire(scope(bb),
+                                      UNSAFE.getReference(bb, BYTE_BUFFER_HB),
+                                      address(bb, indexRO(bb, index)),
+                                      convEndian(handle.be, expected), convEndian(handle.be, value)));
+        }
+
+        @ForceInline
+        static $type$ compareAndExchangeRelease(VarHandle ob, Object obb, int index, $type$ expected, $type$ value) {
+            ByteBufferHandle handle = (ByteBufferHandle)ob;
+            ByteBuffer bb = (ByteBuffer) Objects.requireNonNull(obb);
+            return convEndian(handle.be,
+                              SCOPED_MEMORY_ACCESS.compareAndExchange$RawType$Release(scope(bb),
+                                      UNSAFE.getReference(bb, BYTE_BUFFER_HB),
+                                      address(bb, indexRO(bb, index)),
+                                      convEndian(handle.be, expected), convEndian(handle.be, value)));
+        }
+
+        @ForceInline
+        static boolean weakCompareAndSetPlain(VarHandle ob, Object obb, int index, $type$ expected, $type$ value) {
+            ByteBufferHandle handle = (ByteBufferHandle)ob;
+            ByteBuffer bb = (ByteBuffer) Objects.requireNonNull(obb);
+            return SCOPED_MEMORY_ACCESS.weakCompareAndSet$RawType$Plain(scope(bb),
+                    UNSAFE.getReference(bb, BYTE_BUFFER_HB),
+                    address(bb, indexRO(bb, index)),
+                    convEndian(handle.be, expected), convEndian(handle.be, value));
+        }
+
+        @ForceInline
+        static boolean weakCompareAndSet(VarHandle ob, Object obb, int index, $type$ expected, $type$ value) {
+            ByteBufferHandle handle = (ByteBufferHandle)ob;
+            ByteBuffer bb = (ByteBuffer) Objects.requireNonNull(obb);
+            return SCOPED_MEMORY_ACCESS.weakCompareAndSet$RawType$(scope(bb),
+                    UNSAFE.getReference(bb, BYTE_BUFFER_HB),
+                    address(bb, indexRO(bb, index)),
+                    convEndian(handle.be, expected), convEndian(handle.be, value));
+        }
+
+        @ForceInline
+        static boolean weakCompareAndSetAcquire(VarHandle ob, Object obb, int index, $type$ expected, $type$ value) {
+            ByteBufferHandle handle = (ByteBufferHandle)ob;
+            ByteBuffer bb = (ByteBuffer) Objects.requireNonNull(obb);
+            return SCOPED_MEMORY_ACCESS.weakCompareAndSet$RawType$Acquire(scope(bb),
+                    UNSAFE.getReference(bb, BYTE_BUFFER_HB),
+                    address(bb, indexRO(bb, index)),
+                    convEndian(handle.be, expected), convEndian(handle.be, value));
+        }
+
+        @ForceInline
+        static boolean weakCompareAndSetRelease(VarHandle ob, Object obb, int index, $type$ expected, $type$ value) {
+            ByteBufferHandle handle = (ByteBufferHandle)ob;
+            ByteBuffer bb = (ByteBuffer) Objects.requireNonNull(obb);
+            return SCOPED_MEMORY_ACCESS.weakCompareAndSet$RawType$Release(scope(bb),
+                    UNSAFE.getReference(bb, BYTE_BUFFER_HB),
+                    address(bb, indexRO(bb, index)),
+                    convEndian(handle.be, expected), convEndian(handle.be, value));
+        }
+
+        @ForceInline
+        static $type$ getAndSet(VarHandle ob, Object obb, int index, $type$ value) {
+            ByteBufferHandle handle = (ByteBufferHandle)ob;
+            ByteBuffer bb = (ByteBuffer) Objects.requireNonNull(obb);
+#if[Object]
+            return convEndian(handle.be,
+                              SCOPED_MEMORY_ACCESS.getAndSetReference(scope(bb),
+                                      UNSAFE.getReference(bb, BYTE_BUFFER_HB),
+                                      address(bb, indexRO(bb, index)),
+                                      convEndian(handle.be, value)));
+#else[Object]
+            return convEndian(handle.be,
+                              SCOPED_MEMORY_ACCESS.getAndSet$RawType$(scope(bb),
+                                      UNSAFE.getReference(bb, BYTE_BUFFER_HB),
+                                      address(bb, indexRO(bb, index)),
+                                      convEndian(handle.be, value)));
+#end[Object]
+        }
+
+        @ForceInline
+        static $type$ getAndSetAcquire(VarHandle ob, Object obb, int index, $type$ value) {
+            ByteBufferHandle handle = (ByteBufferHandle)ob;
+            ByteBuffer bb = (ByteBuffer) Objects.requireNonNull(obb);
+            return convEndian(handle.be,
+                              SCOPED_MEMORY_ACCESS.getAndSet$RawType$Acquire(scope(bb),
+                                      UNSAFE.getReference(bb, BYTE_BUFFER_HB),
+                                      address(bb, indexRO(bb, index)),
+                                      convEndian(handle.be, value)));
+        }
+
+        @ForceInline
+        static $type$ getAndSetRelease(VarHandle ob, Object obb, int index, $type$ value) {
+            ByteBufferHandle handle = (ByteBufferHandle)ob;
+            ByteBuffer bb = (ByteBuffer) Objects.requireNonNull(obb);
+            return convEndian(handle.be,
+                              SCOPED_MEMORY_ACCESS.getAndSet$RawType$Release(scope(bb),
+                                      UNSAFE.getReference(bb, BYTE_BUFFER_HB),
+                                      address(bb, indexRO(bb, index)),
+                                      convEndian(handle.be, value)));
+        }
+#end[CAS]
+#if[AtomicAdd]
+
+        @ForceInline
+        static $type$ getAndAdd(VarHandle ob, Object obb, int index, $type$ delta) {
+            ByteBufferHandle handle = (ByteBufferHandle)ob;
+            ByteBuffer bb = (ByteBuffer) Objects.requireNonNull(obb);
+            if (handle.be == BE) {
+                return SCOPED_MEMORY_ACCESS.getAndAdd$RawType$(scope(bb),
+                        UNSAFE.getReference(bb, BYTE_BUFFER_HB),
+                        address(bb, indexRO(bb, index)),
+                        delta);
+            } else {
+                return getAndAddConvEndianWithCAS(bb, index, delta);
+            }
+        }
+
+        @ForceInline
+        static $type$ getAndAddAcquire(VarHandle ob, Object obb, int index, $type$ delta) {
+            ByteBufferHandle handle = (ByteBufferHandle)ob;
+            ByteBuffer bb = (ByteBuffer) Objects.requireNonNull(obb);
+            if (handle.be == BE) {
+                return SCOPED_MEMORY_ACCESS.getAndAdd$RawType$Acquire(scope(bb),
+                        UNSAFE.getReference(bb, BYTE_BUFFER_HB),
+                        address(bb, indexRO(bb, index)),
+                        delta);
+            } else {
+                return getAndAddConvEndianWithCAS(bb, index, delta);
+            }
+        }
+
+        @ForceInline
+        static $type$ getAndAddRelease(VarHandle ob, Object obb, int index, $type$ delta) {
+            ByteBufferHandle handle = (ByteBufferHandle)ob;
+            ByteBuffer bb = (ByteBuffer) Objects.requireNonNull(obb);
+            if (handle.be == BE) {
+                return SCOPED_MEMORY_ACCESS.getAndAdd$RawType$Release(scope(bb),
+                        UNSAFE.getReference(bb, BYTE_BUFFER_HB),
+                        address(bb, indexRO(bb, index)),
+                        delta);
+            } else {
+                return getAndAddConvEndianWithCAS(bb, index, delta);
+            }
+        }
+
+        @ForceInline
+        static $type$ getAndAddConvEndianWithCAS(ByteBuffer bb, int index, $type$ delta) {
+            $type$ nativeExpectedValue, expectedValue;
+            Object base = UNSAFE.getReference(bb, BYTE_BUFFER_HB);
+            long offset = address(bb, indexRO(bb, index));
+            do {
+                nativeExpectedValue = SCOPED_MEMORY_ACCESS.get$RawType$Volatile(scope(bb), base, offset);
+                expectedValue = $RawBoxType$.reverseBytes(nativeExpectedValue);
+            } while (!UNSAFE.weakCompareAndSet$RawType$(base, offset,
+                    nativeExpectedValue, $RawBoxType$.reverseBytes(expectedValue + delta)));
+            return expectedValue;
+        }
+#end[AtomicAdd]
+#if[Bitwise]
+
+        @ForceInline
+        static $type$ getAndBitwiseOr(VarHandle ob, Object obb, int index, $type$ value) {
+            ByteBufferHandle handle = (ByteBufferHandle)ob;
+            ByteBuffer bb = (ByteBuffer) Objects.requireNonNull(obb);
+            if (handle.be == BE) {
+                return SCOPED_MEMORY_ACCESS.getAndBitwiseOr$RawType$(scope(bb),
+                        UNSAFE.getReference(bb, BYTE_BUFFER_HB),
+                        address(bb, indexRO(bb, index)),
+                        value);
+            } else {
+                return getAndBitwiseOrConvEndianWithCAS(bb, index, value);
+            }
+        }
+
+        @ForceInline
+        static $type$ getAndBitwiseOrRelease(VarHandle ob, Object obb, int index, $type$ value) {
+            ByteBufferHandle handle = (ByteBufferHandle)ob;
+            ByteBuffer bb = (ByteBuffer) Objects.requireNonNull(obb);
+            if (handle.be == BE) {
+                return SCOPED_MEMORY_ACCESS.getAndBitwiseOr$RawType$Release(scope(bb),
+                        UNSAFE.getReference(bb, BYTE_BUFFER_HB),
+                        address(bb, indexRO(bb, index)),
+                        value);
+            } else {
+                return getAndBitwiseOrConvEndianWithCAS(bb, index, value);
+            }
+        }
+
+        @ForceInline
+        static $type$ getAndBitwiseOrAcquire(VarHandle ob, Object obb, int index, $type$ value) {
+            ByteBufferHandle handle = (ByteBufferHandle)ob;
+            ByteBuffer bb = (ByteBuffer) Objects.requireNonNull(obb);
+            if (handle.be == BE) {
+                return SCOPED_MEMORY_ACCESS.getAndBitwiseOr$RawType$Acquire(scope(bb),
+                        UNSAFE.getReference(bb, BYTE_BUFFER_HB),
+                        address(bb, indexRO(bb, index)),
+                        value);
+            } else {
+                return getAndBitwiseOrConvEndianWithCAS(bb, index, value);
+            }
+        }
+
+        @ForceInline
+        static $type$ getAndBitwiseOrConvEndianWithCAS(ByteBuffer bb, int index, $type$ value) {
+            $type$ nativeExpectedValue, expectedValue;
+            Object base = UNSAFE.getReference(bb, BYTE_BUFFER_HB);
+            long offset = address(bb, indexRO(bb, index));
+            do {
+                nativeExpectedValue = SCOPED_MEMORY_ACCESS.get$RawType$Volatile(scope(bb), base, offset);
+                expectedValue = $RawBoxType$.reverseBytes(nativeExpectedValue);
+            } while (!UNSAFE.weakCompareAndSet$RawType$(base, offset,
+                    nativeExpectedValue, $RawBoxType$.reverseBytes(expectedValue | value)));
+            return expectedValue;
+        }
+
+        @ForceInline
+        static $type$ getAndBitwiseAnd(VarHandle ob, Object obb, int index, $type$ value) {
+            ByteBufferHandle handle = (ByteBufferHandle)ob;
+            ByteBuffer bb = (ByteBuffer) Objects.requireNonNull(obb);
+            if (handle.be == BE) {
+                return SCOPED_MEMORY_ACCESS.getAndBitwiseAnd$RawType$(scope(bb),
+                        UNSAFE.getReference(bb, BYTE_BUFFER_HB),
+                        address(bb, indexRO(bb, index)),
+                        value);
+            } else {
+                return getAndBitwiseAndConvEndianWithCAS(bb, index, value);
+            }
+        }
+
+        @ForceInline
+        static $type$ getAndBitwiseAndRelease(VarHandle ob, Object obb, int index, $type$ value) {
+            ByteBufferHandle handle = (ByteBufferHandle)ob;
+            ByteBuffer bb = (ByteBuffer) Objects.requireNonNull(obb);
+            if (handle.be == BE) {
+                return SCOPED_MEMORY_ACCESS.getAndBitwiseAnd$RawType$Release(scope(bb),
+                        UNSAFE.getReference(bb, BYTE_BUFFER_HB),
+                        address(bb, indexRO(bb, index)),
+                        value);
+            } else {
+                return getAndBitwiseAndConvEndianWithCAS(bb, index, value);
+            }
+        }
+
+        @ForceInline
+        static $type$ getAndBitwiseAndAcquire(VarHandle ob, Object obb, int index, $type$ value) {
+            ByteBufferHandle handle = (ByteBufferHandle)ob;
+            ByteBuffer bb = (ByteBuffer) Objects.requireNonNull(obb);
+            if (handle.be == BE) {
+                return SCOPED_MEMORY_ACCESS.getAndBitwiseAnd$RawType$Acquire(scope(bb),
+                        UNSAFE.getReference(bb, BYTE_BUFFER_HB),
+                        address(bb, indexRO(bb, index)),
+                        value);
+            } else {
+                return getAndBitwiseAndConvEndianWithCAS(bb, index, value);
+            }
+        }
+
+        @ForceInline
+        static $type$ getAndBitwiseAndConvEndianWithCAS(ByteBuffer bb, int index, $type$ value) {
+            $type$ nativeExpectedValue, expectedValue;
+            Object base = UNSAFE.getReference(bb, BYTE_BUFFER_HB);
+            long offset = address(bb, indexRO(bb, index));
+            do {
+                nativeExpectedValue = SCOPED_MEMORY_ACCESS.get$RawType$Volatile(scope(bb), base, offset);
+                expectedValue = $RawBoxType$.reverseBytes(nativeExpectedValue);
+            } while (!UNSAFE.weakCompareAndSet$RawType$(base, offset,
+                    nativeExpectedValue, $RawBoxType$.reverseBytes(expectedValue & value)));
+            return expectedValue;
+        }
+
+
+        @ForceInline
+        static $type$ getAndBitwiseXor(VarHandle ob, Object obb, int index, $type$ value) {
+            ByteBufferHandle handle = (ByteBufferHandle)ob;
+            ByteBuffer bb = (ByteBuffer) Objects.requireNonNull(obb);
+            if (handle.be == BE) {
+                return SCOPED_MEMORY_ACCESS.getAndBitwiseXor$RawType$(scope(bb),
+                        UNSAFE.getReference(bb, BYTE_BUFFER_HB),
+                        address(bb, indexRO(bb, index)),
+                        value);
+            } else {
+                return getAndBitwiseXorConvEndianWithCAS(bb, index, value);
+            }
+        }
+
+        @ForceInline
+        static $type$ getAndBitwiseXorRelease(VarHandle ob, Object obb, int index, $type$ value) {
+            ByteBufferHandle handle = (ByteBufferHandle)ob;
+            ByteBuffer bb = (ByteBuffer) Objects.requireNonNull(obb);
+            if (handle.be == BE) {
+                return SCOPED_MEMORY_ACCESS.getAndBitwiseXor$RawType$Release(scope(bb),
+                        UNSAFE.getReference(bb, BYTE_BUFFER_HB),
+                        address(bb, indexRO(bb, index)),
+                        value);
+            } else {
+                return getAndBitwiseXorConvEndianWithCAS(bb, index, value);
+            }
+        }
+
+        @ForceInline
+        static $type$ getAndBitwiseXorAcquire(VarHandle ob, Object obb, int index, $type$ value) {
+            ByteBufferHandle handle = (ByteBufferHandle)ob;
+            ByteBuffer bb = (ByteBuffer) Objects.requireNonNull(obb);
+            if (handle.be == BE) {
+                return SCOPED_MEMORY_ACCESS.getAndBitwiseXor$RawType$Acquire(scope(bb),
+                        UNSAFE.getReference(bb, BYTE_BUFFER_HB),
+                        address(bb, indexRO(bb, index)),
+                        value);
+            } else {
+                return getAndBitwiseXorConvEndianWithCAS(bb, index, value);
+            }
+        }
+
+        @ForceInline
+        static $type$ getAndBitwiseXorConvEndianWithCAS(ByteBuffer bb, int index, $type$ value) {
+            $type$ nativeExpectedValue, expectedValue;
+            Object base = UNSAFE.getReference(bb, BYTE_BUFFER_HB);
+            long offset = address(bb, indexRO(bb, index));
+            do {
+                nativeExpectedValue = SCOPED_MEMORY_ACCESS.get$RawType$Volatile(scope(bb), base, offset);
+                expectedValue = $RawBoxType$.reverseBytes(nativeExpectedValue);
+            } while (!UNSAFE.weakCompareAndSet$RawType$(base, offset,
+                    nativeExpectedValue, $RawBoxType$.reverseBytes(expectedValue ^ value)));
+            return expectedValue;
+        }
+#end[Bitwise]
+
+        static final VarForm FORM = new VarForm(ByteBufferHandle.class, ByteBuffer.class, $type$.class, int.class);
+    }
+}

--- a/java.base/src/main/java/java/lang/invoke/X-VarHandleByteArrayView.java.template
+++ b/java.base/src/main/java/java/lang/invoke/X-VarHandleByteArrayView.java.template
@@ -146,6 +146,19 @@ final class VarHandleByteArrayAs$Type$s extends VarHandleByteArrayBase {
 #end[floatingPoint]
         }
 
+        // @Override
+        public $type$ get(Object oba, int index) {
+            byte[] ba = (byte[]) oba;
+#if[floatingPoint]
+            $rawType$ rawValue = UNSAFE.get$RawType$Unaligned(
+                    ba, ((long) index(ba, index)) + Unsafe.ARRAY_BYTE_BASE_OFFSET, be);
+            return $Type$.$rawType$BitsTo$Type$(rawValue);
+#else[floatingPoint]
+            return UNSAFE.get$Type$Unaligned(
+                    ba, ((long) index(ba, index)) + Unsafe.ARRAY_BYTE_BASE_OFFSET, be);
+#end[floatingPoint]
+        }
+
         @ForceInline
         static void set(VarHandle ob, Object oba, int index, $type$ value) {
             ArrayHandle handle = (ArrayHandle)ob;
@@ -165,6 +178,20 @@ final class VarHandleByteArrayAs$Type$s extends VarHandleByteArrayBase {
 #end[floatingPoint]
         }
 
+        // @Override
+        public void set(Object oba, int index, $type$ value) {
+            byte[] ba = (byte[]) oba;
+#if[floatingPoint]
+            UNSAFE.put$RawType$Unaligned(
+                    ba, ((long) index(ba, index)) + Unsafe.ARRAY_BYTE_BASE_OFFSET,
+                    $Type$.$type$ToRaw$RawType$Bits(value), be);
+#else[floatingPoint]
+            UNSAFE.put$RawType$Unaligned(
+                    ba, ((long) index(ba, index)) + Unsafe.ARRAY_BYTE_BASE_OFFSET,
+                    value, be);
+#end[floatingPoint]
+        }
+
         @ForceInline
         static $type$ getVolatile(VarHandle ob, Object oba, int index) {
             ArrayHandle handle = (ArrayHandle)ob;
@@ -173,6 +200,12 @@ final class VarHandleByteArrayAs$Type$s extends VarHandleByteArrayBase {
                               UNSAFE.get$RawType$Volatile(
                                       ba,
                                       address(ba, index(ba, index))));
+        }
+
+        // @Override
+        public $type$ getVolatile(Object oba, int index) {
+            byte[] ba = (byte[]) oba;
+            return convEndian(be, UNSAFE.get$RawType$Volatile(ba, address(ba, index(ba, index))));
         }
 
         @ForceInline
@@ -185,6 +218,12 @@ final class VarHandleByteArrayAs$Type$s extends VarHandleByteArrayBase {
                     convEndian(handle.be, value));
         }
 
+        // @Override
+        public void setVolatile(Object oba, int index, $type$ value) {
+            byte[] ba = (byte[]) oba;
+            UNSAFE.put$RawType$Volatile(ba, address(ba, index(ba, index)), convEndian(be, value));
+        }
+
         @ForceInline
         static $type$ getAcquire(VarHandle ob, Object oba, int index) {
             ArrayHandle handle = (ArrayHandle)ob;
@@ -193,6 +232,12 @@ final class VarHandleByteArrayAs$Type$s extends VarHandleByteArrayBase {
                               UNSAFE.get$RawType$Acquire(
                                       ba,
                                       address(ba, index(ba, index))));
+        }
+
+        // @Override
+        public $type$ getAcquire(Object oba, int index) {
+            byte[] ba = (byte[]) oba;
+            return convEndian(be, UNSAFE.get$RawType$Acquire(ba, address(ba, index(ba, index))));
         }
 
         @ForceInline
@@ -205,6 +250,12 @@ final class VarHandleByteArrayAs$Type$s extends VarHandleByteArrayBase {
                     convEndian(handle.be, value));
         }
 
+        // @Override
+        public void setRelease(Object oba, int index, $type$ value) {
+            byte[] ba = (byte[]) oba;
+            UNSAFE.put$RawType$Release(ba, address(ba, index(ba, index)), convEndian(be, value));
+        }
+
         @ForceInline
         static $type$ getOpaque(VarHandle ob, Object oba, int index) {
             ArrayHandle handle = (ArrayHandle)ob;
@@ -215,6 +266,12 @@ final class VarHandleByteArrayAs$Type$s extends VarHandleByteArrayBase {
                                       address(ba, index(ba, index))));
         }
 
+        // @Override
+        public $type$ getOpaque(Object oba, int index) {
+            byte[] ba = (byte[]) oba;
+            return convEndian(be, UNSAFE.get$RawType$Opaque(ba, address(ba, index(ba, index))));
+        }
+
         @ForceInline
         static void setOpaque(VarHandle ob, Object oba, int index, $type$ value) {
             ArrayHandle handle = (ArrayHandle)ob;
@@ -223,6 +280,12 @@ final class VarHandleByteArrayAs$Type$s extends VarHandleByteArrayBase {
                     ba,
                     address(ba, index(ba, index)),
                     convEndian(handle.be, value));
+        }
+
+        // @Override
+        public void setOpaque(Object oba, int index, $type$ value) {
+            byte[] ba = (byte[]) oba;
+            UNSAFE.put$RawType$Opaque(ba, address(ba, index(ba, index)), convEndian(be, value));
         }
 #if[CAS]
 
@@ -243,6 +306,20 @@ final class VarHandleByteArrayAs$Type$s extends VarHandleByteArrayBase {
 #end[Object]
         }
 
+        // @Override
+        public boolean compareAndSet(Object oba, int index, $type$ expected, $type$ value) {
+            byte[] ba = (byte[]) oba;
+#if[Object]
+            return UNSAFE.compareAndSetReference(
+                    ba, address(ba, index(ba, index)),
+                    convEndian(be, expected), convEndian(be, value));
+#else[Object]
+            return UNSAFE.compareAndSet$RawType$(
+                    ba, address(ba, index(ba, index)),
+                    convEndian(be, expected), convEndian(be, value));
+#end[Object]
+        }
+
         @ForceInline
         static $type$ compareAndExchange(VarHandle ob, Object oba, int index, $type$ expected, $type$ value) {
             ArrayHandle handle = (ArrayHandle)ob;
@@ -252,6 +329,14 @@ final class VarHandleByteArrayAs$Type$s extends VarHandleByteArrayBase {
                                       ba,
                                       address(ba, index(ba, index)),
                                       convEndian(handle.be, expected), convEndian(handle.be, value)));
+        }
+
+        // @Override
+        public $type$ compareAndExchange(Object oba, int index, $type$ expected, $type$ value) {
+            byte[] ba = (byte[]) oba;
+            return convEndian(be, UNSAFE.compareAndExchange$RawType$(
+                    ba, address(ba, index(ba, index)),
+                    convEndian(be, expected), convEndian(be, value)));
         }
 
         @ForceInline
@@ -265,6 +350,14 @@ final class VarHandleByteArrayAs$Type$s extends VarHandleByteArrayBase {
                                       convEndian(handle.be, expected), convEndian(handle.be, value)));
         }
 
+        // @Override
+        public $type$ compareAndExchangeAcquire(Object oba, int index, $type$ expected, $type$ value) {
+            byte[] ba = (byte[]) oba;
+            return convEndian(be, UNSAFE.compareAndExchange$RawType$Acquire(
+                    ba, address(ba, index(ba, index)),
+                    convEndian(be, expected), convEndian(be, value)));
+        }
+
         @ForceInline
         static $type$ compareAndExchangeRelease(VarHandle ob, Object oba, int index, $type$ expected, $type$ value) {
             ArrayHandle handle = (ArrayHandle)ob;
@@ -274,6 +367,14 @@ final class VarHandleByteArrayAs$Type$s extends VarHandleByteArrayBase {
                                       ba,
                                       address(ba, index(ba, index)),
                                       convEndian(handle.be, expected), convEndian(handle.be, value)));
+        }
+
+        // @Override
+        public $type$ compareAndExchangeRelease(Object oba, int index, $type$ expected, $type$ value) {
+            byte[] ba = (byte[]) oba;
+            return convEndian(be, UNSAFE.compareAndExchange$RawType$Release(
+                    ba, address(ba, index(ba, index)),
+                    convEndian(be, expected), convEndian(be, value)));
         }
 
         @ForceInline
@@ -286,6 +387,14 @@ final class VarHandleByteArrayAs$Type$s extends VarHandleByteArrayBase {
                     convEndian(handle.be, expected), convEndian(handle.be, value));
         }
 
+        // @Override
+        public boolean weakCompareAndSetPlain(Object oba, int index, $type$ expected, $type$ value) {
+            byte[] ba = (byte[]) oba;
+            return UNSAFE.weakCompareAndSet$RawType$Plain(
+                    ba, address(ba, index(ba, index)),
+                    convEndian(be, expected), convEndian(be, value));
+        }
+
         @ForceInline
         static boolean weakCompareAndSet(VarHandle ob, Object oba, int index, $type$ expected, $type$ value) {
             ArrayHandle handle = (ArrayHandle)ob;
@@ -294,6 +403,14 @@ final class VarHandleByteArrayAs$Type$s extends VarHandleByteArrayBase {
                     ba,
                     address(ba, index(ba, index)),
                     convEndian(handle.be, expected), convEndian(handle.be, value));
+        }
+
+        // @Override
+        public boolean weakCompareAndSet(Object oba, int index, $type$ expected, $type$ value) {
+            byte[] ba = (byte[]) oba;
+            return UNSAFE.weakCompareAndSet$RawType$(
+                    ba, address(ba, index(ba, index)),
+                    convEndian(be, expected), convEndian(be, value));
         }
 
         @ForceInline
@@ -306,6 +423,14 @@ final class VarHandleByteArrayAs$Type$s extends VarHandleByteArrayBase {
                     convEndian(handle.be, expected), convEndian(handle.be, value));
         }
 
+        // @Override
+        public boolean weakCompareAndSetAcquire(Object oba, int index, $type$ expected, $type$ value) {
+            byte[] ba = (byte[]) oba;
+            return UNSAFE.weakCompareAndSet$RawType$Acquire(
+                    ba, address(ba, index(ba, index)),
+                    convEndian(be, expected), convEndian(be, value));
+        }
+
         @ForceInline
         static boolean weakCompareAndSetRelease(VarHandle ob, Object oba, int index, $type$ expected, $type$ value) {
             ArrayHandle handle = (ArrayHandle)ob;
@@ -314,6 +439,14 @@ final class VarHandleByteArrayAs$Type$s extends VarHandleByteArrayBase {
                     ba,
                     address(ba, index(ba, index)),
                     convEndian(handle.be, expected), convEndian(handle.be, value));
+        }
+
+        // @Override
+        public boolean weakCompareAndSetRelease(Object oba, int index, $type$ expected, $type$ value) {
+            byte[] ba = (byte[]) oba;
+            return UNSAFE.weakCompareAndSet$RawType$Release(
+                    ba, address(ba, index(ba, index)),
+                    convEndian(be, expected), convEndian(be, value));
         }
 
         @ForceInline
@@ -335,6 +468,16 @@ final class VarHandleByteArrayAs$Type$s extends VarHandleByteArrayBase {
 #end[Object]
         }
 
+        // @Override
+        public $type$ getAndSet(Object oba, int index, $type$ value) {
+            byte[] ba = (byte[]) oba;
+#if[Object]
+            return convEndian(be, UNSAFE.getAndSetReference(ba, address(ba, index(ba, index)), convEndian(be, value)));
+#else[Object]
+            return convEndian(be, UNSAFE.getAndSet$RawType$(ba, address(ba, index(ba, index)), convEndian(be, value)));
+#end[Object]
+        }
+
         @ForceInline
         static $type$ getAndSetAcquire(VarHandle ob, Object oba, int index, $type$ value) {
             ArrayHandle handle = (ArrayHandle)ob;
@@ -346,6 +489,12 @@ final class VarHandleByteArrayAs$Type$s extends VarHandleByteArrayBase {
                                       convEndian(handle.be, value)));
         }
 
+        // @Override
+        public $type$ getAndSetAcquire(Object oba, int index, $type$ value) {
+            byte[] ba = (byte[]) oba;
+            return convEndian(be, UNSAFE.getAndSet$RawType$Acquire(ba, address(ba, index(ba, index)), convEndian(be, value)));
+        }
+
         @ForceInline
         static $type$ getAndSetRelease(VarHandle ob, Object oba, int index, $type$ value) {
             ArrayHandle handle = (ArrayHandle)ob;
@@ -355,6 +504,12 @@ final class VarHandleByteArrayAs$Type$s extends VarHandleByteArrayBase {
                                       ba,
                                       address(ba, index(ba, index)),
                                       convEndian(handle.be, value)));
+        }
+
+        // @Override
+        public $type$ getAndSetRelease(Object oba, int index, $type$ value) {
+            byte[] ba = (byte[]) oba;
+            return convEndian(be, UNSAFE.getAndSet$RawType$Release(ba, address(ba, index(ba, index)), convEndian(be, value)));
         }
 #end[CAS]
 #if[AtomicAdd]
@@ -368,6 +523,16 @@ final class VarHandleByteArrayAs$Type$s extends VarHandleByteArrayBase {
                         ba,
                         address(ba, index(ba, index)),
                         delta);
+            } else {
+                return getAndAddConvEndianWithCAS(ba, index, delta);
+            }
+        }
+
+        // @Override
+        public $type$ getAndAdd(Object oba, int index, $type$ delta) {
+            byte[] ba = (byte[]) oba;
+            if (be == BE) {
+                return UNSAFE.getAndAdd$RawType$(ba, address(ba, index(ba, index)), delta);
             } else {
                 return getAndAddConvEndianWithCAS(ba, index, delta);
             }
@@ -387,6 +552,16 @@ final class VarHandleByteArrayAs$Type$s extends VarHandleByteArrayBase {
             }
         }
 
+        // @Override
+        public $type$ getAndAddAcquire(Object oba, int index, $type$ delta) {
+            byte[] ba = (byte[]) oba;
+            if (be == BE) {
+                return UNSAFE.getAndAdd$RawType$Acquire(ba, address(ba, index(ba, index)), delta);
+            } else {
+                return getAndAddConvEndianWithCAS(ba, index, delta);
+            }
+        }
+
         @ForceInline
         static $type$ getAndAddRelease(VarHandle ob, Object oba, int index, $type$ delta) {
             ArrayHandle handle = (ArrayHandle)ob;
@@ -396,6 +571,16 @@ final class VarHandleByteArrayAs$Type$s extends VarHandleByteArrayBase {
                         ba,
                         address(ba, index(ba, index)),
                         delta);
+            } else {
+                return getAndAddConvEndianWithCAS(ba, index, delta);
+            }
+        }
+
+        // @Override
+        public $type$ getAndAddRelease(Object oba, int index, $type$ delta) {
+            byte[] ba = (byte[]) oba;
+            if (be == BE) {
+                return UNSAFE.getAndAdd$RawType$Release(ba, address(ba, index(ba, index)), delta);
             } else {
                 return getAndAddConvEndianWithCAS(ba, index, delta);
             }
@@ -429,6 +614,16 @@ final class VarHandleByteArrayAs$Type$s extends VarHandleByteArrayBase {
             }
         }
 
+        // @Override
+        public $type$ getAndBitwiseOr(Object oba, int index, $type$ value) {
+            byte[] ba = (byte[]) oba;
+            if (be == BE) {
+                return UNSAFE.getAndBitwiseOr$RawType$(ba, address(ba, index(ba, index)), value);
+            } else {
+                return getAndBitwiseOrConvEndianWithCAS(ba, index, value);
+            }
+        }
+
         @ForceInline
         static $type$ getAndBitwiseOrRelease(VarHandle ob, Object oba, int index, $type$ value) {
             ArrayHandle handle = (ArrayHandle)ob;
@@ -443,6 +638,16 @@ final class VarHandleByteArrayAs$Type$s extends VarHandleByteArrayBase {
             }
         }
 
+        // @Override
+        public $type$ getAndBitwiseOrRelease(Object oba, int index, $type$ value) {
+            byte[] ba = (byte[]) oba;
+            if (be == BE) {
+                return UNSAFE.getAndBitwiseOr$RawType$Release(ba, address(ba, index(ba, index)), value);
+            } else {
+                return getAndBitwiseOrConvEndianWithCAS(ba, index, value);
+            }
+        }
+
         @ForceInline
         static $type$ getAndBitwiseOrAcquire(VarHandle ob, Object oba, int index, $type$ value) {
             ArrayHandle handle = (ArrayHandle)ob;
@@ -452,6 +657,16 @@ final class VarHandleByteArrayAs$Type$s extends VarHandleByteArrayBase {
                         ba,
                         address(ba, index(ba, index)),
                         value);
+            } else {
+                return getAndBitwiseOrConvEndianWithCAS(ba, index, value);
+            }
+        }
+
+        // @Override
+        public $type$ getAndBitwiseOrAcquire(Object oba, int index, $type$ value) {
+            byte[] ba = (byte[]) oba;
+            if (be == BE) {
+                return UNSAFE.getAndBitwiseOr$RawType$Acquire(ba, address(ba, index(ba, index)), value);
             } else {
                 return getAndBitwiseOrConvEndianWithCAS(ba, index, value);
             }
@@ -483,6 +698,16 @@ final class VarHandleByteArrayAs$Type$s extends VarHandleByteArrayBase {
             }
         }
 
+        // @Override
+        public $type$ getAndBitwiseAnd(Object oba, int index, $type$ value) {
+            byte[] ba = (byte[]) oba;
+            if (be == BE) {
+                return UNSAFE.getAndBitwiseAnd$RawType$(ba, address(ba, index(ba, index)), value);
+            } else {
+                return getAndBitwiseAndConvEndianWithCAS(ba, index, value);
+            }
+        }
+
         @ForceInline
         static $type$ getAndBitwiseAndRelease(VarHandle ob, Object oba, int index, $type$ value) {
             ArrayHandle handle = (ArrayHandle)ob;
@@ -497,6 +722,16 @@ final class VarHandleByteArrayAs$Type$s extends VarHandleByteArrayBase {
             }
         }
 
+        // @Override
+        public $type$ getAndBitwiseAndRelease(Object oba, int index, $type$ value) {
+            byte[] ba = (byte[]) oba;
+            if (be == BE) {
+                return UNSAFE.getAndBitwiseAnd$RawType$Release(ba, address(ba, index(ba, index)), value);
+            } else {
+                return getAndBitwiseAndConvEndianWithCAS(ba, index, value);
+            }
+        }
+
         @ForceInline
         static $type$ getAndBitwiseAndAcquire(VarHandle ob, Object oba, int index, $type$ value) {
             ArrayHandle handle = (ArrayHandle)ob;
@@ -506,6 +741,16 @@ final class VarHandleByteArrayAs$Type$s extends VarHandleByteArrayBase {
                         ba,
                         address(ba, index(ba, index)),
                         value);
+            } else {
+                return getAndBitwiseAndConvEndianWithCAS(ba, index, value);
+            }
+        }
+
+        // @Override
+        public $type$ getAndBitwiseAndAcquire(Object oba, int index, $type$ value) {
+            byte[] ba = (byte[]) oba;
+            if (be == BE) {
+                return UNSAFE.getAndBitwiseAnd$RawType$Acquire(ba, address(ba, index(ba, index)), value);
             } else {
                 return getAndBitwiseAndConvEndianWithCAS(ba, index, value);
             }
@@ -537,6 +782,16 @@ final class VarHandleByteArrayAs$Type$s extends VarHandleByteArrayBase {
             }
         }
 
+        // @Override
+        public $type$ getAndBitwiseXor(Object oba, int index, $type$ value) {
+            byte[] ba = (byte[]) oba;
+            if (be == BE) {
+                return UNSAFE.getAndBitwiseXor$RawType$(ba, address(ba, index(ba, index)), value);
+            } else {
+                return getAndBitwiseXorConvEndianWithCAS(ba, index, value);
+            }
+        }
+
         @ForceInline
         static $type$ getAndBitwiseXorRelease(VarHandle ob, Object oba, int index, $type$ value) {
             ArrayHandle handle = (ArrayHandle)ob;
@@ -551,6 +806,16 @@ final class VarHandleByteArrayAs$Type$s extends VarHandleByteArrayBase {
             }
         }
 
+        // @Override
+        public $type$ getAndBitwiseXorRelease(Object oba, int index, $type$ value) {
+            byte[] ba = (byte[]) oba;
+            if (be == BE) {
+                return UNSAFE.getAndBitwiseXor$RawType$Release(ba, address(ba, index(ba, index)), value);
+            } else {
+                return getAndBitwiseXorConvEndianWithCAS(ba, index, value);
+            }
+        }
+
         @ForceInline
         static $type$ getAndBitwiseXorAcquire(VarHandle ob, Object oba, int index, $type$ value) {
             ArrayHandle handle = (ArrayHandle)ob;
@@ -560,6 +825,16 @@ final class VarHandleByteArrayAs$Type$s extends VarHandleByteArrayBase {
                         ba,
                         address(ba, index(ba, index)),
                         value);
+            } else {
+                return getAndBitwiseXorConvEndianWithCAS(ba, index, value);
+            }
+        }
+
+        // @Override
+        public $type$ getAndBitwiseXorAcquire(Object oba, int index, $type$ value) {
+            byte[] ba = (byte[]) oba;
+            if (be == BE) {
+                return UNSAFE.getAndBitwiseXor$RawType$Acquire(ba, address(ba, index(ba, index)), value);
             } else {
                 return getAndBitwiseXorConvEndianWithCAS(ba, index, value);
             }
@@ -657,6 +932,22 @@ final class VarHandleByteArrayAs$Type$s extends VarHandleByteArrayBase {
 #end[floatingPoint]
         }
 
+        // @Override
+        public $type$ get(Object obb, int index) {
+            ByteBuffer bb = (ByteBuffer) Objects.requireNonNull(obb);
+#if[floatingPoint]
+            $rawType$ rawValue = SCOPED_MEMORY_ACCESS.get$RawType$Unaligned(scope(bb),
+                    UNSAFE.getReference(bb, BYTE_BUFFER_HB),
+                    ((long) index(bb, index)) + UNSAFE.getLong(bb, BUFFER_ADDRESS), be);
+            return $Type$.$rawType$BitsTo$Type$(rawValue);
+#else[floatingPoint]
+            return SCOPED_MEMORY_ACCESS.get$Type$Unaligned(scope(bb),
+                    UNSAFE.getReference(bb, BYTE_BUFFER_HB),
+                    ((long) index(bb, index)) + UNSAFE.getLong(bb, BUFFER_ADDRESS),
+                    be);
+#end[floatingPoint]
+        }
+
         @ForceInline
         static void set(VarHandle ob, Object obb, int index, $type$ value) {
             ByteBufferHandle handle = (ByteBufferHandle)ob;
@@ -676,6 +967,22 @@ final class VarHandleByteArrayAs$Type$s extends VarHandleByteArrayBase {
 #end[floatingPoint]
         }
 
+        // @Override
+        public void set(Object obb, int index, $type$ value) {
+            ByteBuffer bb = (ByteBuffer) Objects.requireNonNull(obb);
+#if[floatingPoint]
+            SCOPED_MEMORY_ACCESS.put$RawType$Unaligned(scope(bb),
+                    UNSAFE.getReference(bb, BYTE_BUFFER_HB),
+                    ((long) indexRO(bb, index)) + UNSAFE.getLong(bb, BUFFER_ADDRESS),
+                    $Type$.$type$ToRaw$RawType$Bits(value), be);
+#else[floatingPoint]
+            SCOPED_MEMORY_ACCESS.put$Type$Unaligned(scope(bb),
+                    UNSAFE.getReference(bb, BYTE_BUFFER_HB),
+                    ((long) indexRO(bb, index)) + UNSAFE.getLong(bb, BUFFER_ADDRESS),
+                    value, be);
+#end[floatingPoint]
+        }
+
         @ForceInline
         static $type$ getVolatile(VarHandle ob, Object obb, int index) {
             ByteBufferHandle handle = (ByteBufferHandle)ob;
@@ -684,6 +991,14 @@ final class VarHandleByteArrayAs$Type$s extends VarHandleByteArrayBase {
                               SCOPED_MEMORY_ACCESS.get$RawType$Volatile(scope(bb),
                                       UNSAFE.getReference(bb, BYTE_BUFFER_HB),
                                       address(bb, index(bb, index))));
+        }
+
+        // @Override
+        public $type$ getVolatile(Object obb, int index) {
+            ByteBuffer bb = (ByteBuffer) Objects.requireNonNull(obb);
+            return convEndian(be, SCOPED_MEMORY_ACCESS.get$RawType$Volatile(scope(bb),
+                              UNSAFE.getReference(bb, BYTE_BUFFER_HB),
+                              address(bb, index(bb, index))));
         }
 
         @ForceInline
@@ -696,6 +1011,15 @@ final class VarHandleByteArrayAs$Type$s extends VarHandleByteArrayBase {
                     convEndian(handle.be, value));
         }
 
+        // @Override
+        public void setVolatile(Object obb, int index, $type$ value) {
+            ByteBuffer bb = (ByteBuffer) Objects.requireNonNull(obb);
+            SCOPED_MEMORY_ACCESS.put$RawType$Volatile(scope(bb),
+                    UNSAFE.getReference(bb, BYTE_BUFFER_HB),
+                    address(bb, indexRO(bb, index)),
+                    convEndian(be, value));
+        }
+
         @ForceInline
         static $type$ getAcquire(VarHandle ob, Object obb, int index) {
             ByteBufferHandle handle = (ByteBufferHandle)ob;
@@ -704,6 +1028,14 @@ final class VarHandleByteArrayAs$Type$s extends VarHandleByteArrayBase {
                               SCOPED_MEMORY_ACCESS.get$RawType$Acquire(scope(bb),
                                       UNSAFE.getReference(bb, BYTE_BUFFER_HB),
                                       address(bb, index(bb, index))));
+        }
+
+        // @Override
+        public $type$ getAcquire(Object obb, int index) {
+            ByteBuffer bb = (ByteBuffer) Objects.requireNonNull(obb);
+            return convEndian(be, SCOPED_MEMORY_ACCESS.get$RawType$Acquire(scope(bb),
+                              UNSAFE.getReference(bb, BYTE_BUFFER_HB),
+                              address(bb, index(bb, index))));
         }
 
         @ForceInline
@@ -716,6 +1048,15 @@ final class VarHandleByteArrayAs$Type$s extends VarHandleByteArrayBase {
                     convEndian(handle.be, value));
         }
 
+        // @Override
+        public void setRelease(Object obb, int index, $type$ value) {
+            ByteBuffer bb = (ByteBuffer) Objects.requireNonNull(obb);
+            SCOPED_MEMORY_ACCESS.put$RawType$Release(scope(bb),
+                    UNSAFE.getReference(bb, BYTE_BUFFER_HB),
+                    address(bb, indexRO(bb, index)),
+                    convEndian(be, value));
+        }
+
         @ForceInline
         static $type$ getOpaque(VarHandle ob, Object obb, int index) {
             ByteBufferHandle handle = (ByteBufferHandle)ob;
@@ -726,6 +1067,14 @@ final class VarHandleByteArrayAs$Type$s extends VarHandleByteArrayBase {
                                       address(bb, index(bb, index))));
         }
 
+        // @Override
+        public $type$ getOpaque(Object obb, int index) {
+            ByteBuffer bb = (ByteBuffer) Objects.requireNonNull(obb);
+            return convEndian(be, SCOPED_MEMORY_ACCESS.get$RawType$Opaque(scope(bb),
+                              UNSAFE.getReference(bb, BYTE_BUFFER_HB),
+                              address(bb, index(bb, index))));
+        }
+
         @ForceInline
         static void setOpaque(VarHandle ob, Object obb, int index, $type$ value) {
             ByteBufferHandle handle = (ByteBufferHandle)ob;
@@ -734,6 +1083,15 @@ final class VarHandleByteArrayAs$Type$s extends VarHandleByteArrayBase {
                     UNSAFE.getReference(bb, BYTE_BUFFER_HB),
                     address(bb, indexRO(bb, index)),
                     convEndian(handle.be, value));
+        }
+
+        // @Override
+        public void setOpaque(Object obb, int index, $type$ value) {
+            ByteBuffer bb = (ByteBuffer) Objects.requireNonNull(obb);
+            SCOPED_MEMORY_ACCESS.put$RawType$Volatile(scope(bb),
+                    UNSAFE.getReference(bb, BYTE_BUFFER_HB),
+                    address(bb, indexRO(bb, index)),
+                    convEndian(be, value));
         }
 #if[CAS]
 
@@ -754,6 +1112,22 @@ final class VarHandleByteArrayAs$Type$s extends VarHandleByteArrayBase {
 #end[Object]
         }
 
+        // @Override
+        public boolean compareAndSet(Object obb, int index, $type$ expected, $type$ value) {
+            ByteBuffer bb = (ByteBuffer) Objects.requireNonNull(obb);
+#if[Object]
+            return SCOPED_MEMORY_ACCESS.compareAndSetReference(scope(bb),
+                    UNSAFE.getReference(bb, BYTE_BUFFER_HB),
+                    address(bb, indexRO(bb, index)),
+                    convEndian(be, expected), convEndian(be, value));
+#else[Object]
+            return SCOPED_MEMORY_ACCESS.compareAndSet$RawType$(scope(bb),
+                    UNSAFE.getReference(bb, BYTE_BUFFER_HB),
+                    address(bb, indexRO(bb, index)),
+                    convEndian(be, expected), convEndian(be, value));
+#end[Object]
+        }
+
         @ForceInline
         static $type$ compareAndExchange(VarHandle ob, Object obb, int index, $type$ expected, $type$ value) {
             ByteBufferHandle handle = (ByteBufferHandle)ob;
@@ -763,6 +1137,15 @@ final class VarHandleByteArrayAs$Type$s extends VarHandleByteArrayBase {
                                       UNSAFE.getReference(bb, BYTE_BUFFER_HB),
                                       address(bb, indexRO(bb, index)),
                                       convEndian(handle.be, expected), convEndian(handle.be, value)));
+        }
+
+        // @Override
+        public $type$ compareAndExchange(Object obb, int index, $type$ expected, $type$ value) {
+            ByteBuffer bb = (ByteBuffer) Objects.requireNonNull(obb);
+            return convEndian(be, SCOPED_MEMORY_ACCESS.compareAndExchange$RawType$(scope(bb),
+                              UNSAFE.getReference(bb, BYTE_BUFFER_HB),
+                              address(bb, indexRO(bb, index)),
+                              convEndian(be, expected), convEndian(be, value)));
         }
 
         @ForceInline
@@ -776,6 +1159,15 @@ final class VarHandleByteArrayAs$Type$s extends VarHandleByteArrayBase {
                                       convEndian(handle.be, expected), convEndian(handle.be, value)));
         }
 
+        // @Override
+        public $type$ compareAndExchangeAcquire(Object obb, int index, $type$ expected, $type$ value) {
+            ByteBuffer bb = (ByteBuffer) Objects.requireNonNull(obb);
+            return convEndian(be, SCOPED_MEMORY_ACCESS.compareAndExchange$RawType$Acquire(scope(bb),
+                              UNSAFE.getReference(bb, BYTE_BUFFER_HB),
+                              address(bb, indexRO(bb, index)),
+                              convEndian(be, expected), convEndian(be, value)));
+        }
+
         @ForceInline
         static $type$ compareAndExchangeRelease(VarHandle ob, Object obb, int index, $type$ expected, $type$ value) {
             ByteBufferHandle handle = (ByteBufferHandle)ob;
@@ -785,6 +1177,15 @@ final class VarHandleByteArrayAs$Type$s extends VarHandleByteArrayBase {
                                       UNSAFE.getReference(bb, BYTE_BUFFER_HB),
                                       address(bb, indexRO(bb, index)),
                                       convEndian(handle.be, expected), convEndian(handle.be, value)));
+        }
+
+        // @Override
+        public $type$ compareAndExchangeRelease(Object obb, int index, $type$ expected, $type$ value) {
+            ByteBuffer bb = (ByteBuffer) Objects.requireNonNull(obb);
+            return convEndian(be, SCOPED_MEMORY_ACCESS.compareAndExchange$RawType$Release(scope(bb),
+                              UNSAFE.getReference(bb, BYTE_BUFFER_HB),
+                              address(bb, indexRO(bb, index)),
+                              convEndian(be, expected), convEndian(be, value)));
         }
 
         @ForceInline
@@ -797,6 +1198,15 @@ final class VarHandleByteArrayAs$Type$s extends VarHandleByteArrayBase {
                     convEndian(handle.be, expected), convEndian(handle.be, value));
         }
 
+        // @Override
+        public boolean weakCompareAndSetPlain(Object obb, int index, $type$ expected, $type$ value) {
+            ByteBuffer bb = (ByteBuffer) Objects.requireNonNull(obb);
+            return SCOPED_MEMORY_ACCESS.weakCompareAndSet$RawType$Plain(scope(bb),
+                    UNSAFE.getReference(bb, BYTE_BUFFER_HB),
+                    address(bb, indexRO(bb, index)),
+                    convEndian(be, expected), convEndian(be, value));
+        }
+
         @ForceInline
         static boolean weakCompareAndSet(VarHandle ob, Object obb, int index, $type$ expected, $type$ value) {
             ByteBufferHandle handle = (ByteBufferHandle)ob;
@@ -805,6 +1215,15 @@ final class VarHandleByteArrayAs$Type$s extends VarHandleByteArrayBase {
                     UNSAFE.getReference(bb, BYTE_BUFFER_HB),
                     address(bb, indexRO(bb, index)),
                     convEndian(handle.be, expected), convEndian(handle.be, value));
+        }
+
+        // @Override
+        public boolean weakCompareAndSet(Object obb, int index, $type$ expected, $type$ value) {
+            ByteBuffer bb = (ByteBuffer) Objects.requireNonNull(obb);
+            return SCOPED_MEMORY_ACCESS.weakCompareAndSet$RawType$(scope(bb),
+                    UNSAFE.getReference(bb, BYTE_BUFFER_HB),
+                    address(bb, indexRO(bb, index)),
+                    convEndian(be, expected), convEndian(be, value));
         }
 
         @ForceInline
@@ -817,6 +1236,15 @@ final class VarHandleByteArrayAs$Type$s extends VarHandleByteArrayBase {
                     convEndian(handle.be, expected), convEndian(handle.be, value));
         }
 
+        // @Override
+        public boolean weakCompareAndSetAcquire(Object obb, int index, $type$ expected, $type$ value) {
+            ByteBuffer bb = (ByteBuffer) Objects.requireNonNull(obb);
+            return SCOPED_MEMORY_ACCESS.weakCompareAndSet$RawType$Acquire(scope(bb),
+                    UNSAFE.getReference(bb, BYTE_BUFFER_HB),
+                    address(bb, indexRO(bb, index)),
+                    convEndian(be, expected), convEndian(be, value));
+        }
+
         @ForceInline
         static boolean weakCompareAndSetRelease(VarHandle ob, Object obb, int index, $type$ expected, $type$ value) {
             ByteBufferHandle handle = (ByteBufferHandle)ob;
@@ -825,6 +1253,15 @@ final class VarHandleByteArrayAs$Type$s extends VarHandleByteArrayBase {
                     UNSAFE.getReference(bb, BYTE_BUFFER_HB),
                     address(bb, indexRO(bb, index)),
                     convEndian(handle.be, expected), convEndian(handle.be, value));
+        }
+
+        // @Override
+        public boolean weakCompareAndSetRelease(Object obb, int index, $type$ expected, $type$ value) {
+            ByteBuffer bb = (ByteBuffer) Objects.requireNonNull(obb);
+            return SCOPED_MEMORY_ACCESS.weakCompareAndSet$RawType$Release(scope(bb),
+                    UNSAFE.getReference(bb, BYTE_BUFFER_HB),
+                    address(bb, indexRO(bb, index)),
+                    convEndian(be, expected), convEndian(be, value));
         }
 
         @ForceInline
@@ -846,6 +1283,22 @@ final class VarHandleByteArrayAs$Type$s extends VarHandleByteArrayBase {
 #end[Object]
         }
 
+        // @Override
+        public $type$ getAndSet(Object obb, int index, $type$ value) {
+            ByteBuffer bb = (ByteBuffer) Objects.requireNonNull(obb);
+#if[Object]
+            return convEndian(be, SCOPED_MEMORY_ACCESS.getAndSetReference(scope(bb),
+                    UNSAFE.getReference(bb, BYTE_BUFFER_HB),
+                    address(bb, indexRO(bb, index)),
+                    convEndian(be, value)));
+#else[Object]
+            return convEndian(be, SCOPED_MEMORY_ACCESS.getAndSet$RawType$(scope(bb),
+                    UNSAFE.getReference(bb, BYTE_BUFFER_HB),
+                    address(bb, indexRO(bb, index)),
+                    convEndian(be, value)));
+#end[Object]
+        }
+
         @ForceInline
         static $type$ getAndSetAcquire(VarHandle ob, Object obb, int index, $type$ value) {
             ByteBufferHandle handle = (ByteBufferHandle)ob;
@@ -855,6 +1308,15 @@ final class VarHandleByteArrayAs$Type$s extends VarHandleByteArrayBase {
                                       UNSAFE.getReference(bb, BYTE_BUFFER_HB),
                                       address(bb, indexRO(bb, index)),
                                       convEndian(handle.be, value)));
+        }
+
+        // @Override
+        public $type$ getAndSetAcquire(Object obb, int index, $type$ value) {
+            ByteBuffer bb = (ByteBuffer) Objects.requireNonNull(obb);
+            return convEndian(be, SCOPED_MEMORY_ACCESS.getAndSet$RawType$Acquire(scope(bb),
+                    UNSAFE.getReference(bb, BYTE_BUFFER_HB),
+                    address(bb, indexRO(bb, index)),
+                    convEndian(be, value)));
         }
 
         @ForceInline
@@ -867,6 +1329,15 @@ final class VarHandleByteArrayAs$Type$s extends VarHandleByteArrayBase {
                                       address(bb, indexRO(bb, index)),
                                       convEndian(handle.be, value)));
         }
+
+        // @Override
+        public $type$ getAndSetRelease(Object obb, int index, $type$ value) {
+            ByteBuffer bb = (ByteBuffer) Objects.requireNonNull(obb);
+            return convEndian(be, SCOPED_MEMORY_ACCESS.getAndSet$RawType$Release(scope(bb),
+                    UNSAFE.getReference(bb, BYTE_BUFFER_HB),
+                    address(bb, indexRO(bb, index)),
+                    convEndian(be, value)));
+        }
 #end[CAS]
 #if[AtomicAdd]
 
@@ -875,6 +1346,19 @@ final class VarHandleByteArrayAs$Type$s extends VarHandleByteArrayBase {
             ByteBufferHandle handle = (ByteBufferHandle)ob;
             ByteBuffer bb = (ByteBuffer) Objects.requireNonNull(obb);
             if (handle.be == BE) {
+                return SCOPED_MEMORY_ACCESS.getAndAdd$RawType$(scope(bb),
+                        UNSAFE.getReference(bb, BYTE_BUFFER_HB),
+                        address(bb, indexRO(bb, index)),
+                        delta);
+            } else {
+                return getAndAddConvEndianWithCAS(bb, index, delta);
+            }
+        }
+
+        // @Override
+        public $type$ getAndAdd(Object obb, int index, $type$ delta) {
+            ByteBuffer bb = (ByteBuffer) Objects.requireNonNull(obb);
+            if (be == BE) {
                 return SCOPED_MEMORY_ACCESS.getAndAdd$RawType$(scope(bb),
                         UNSAFE.getReference(bb, BYTE_BUFFER_HB),
                         address(bb, indexRO(bb, index)),
@@ -898,11 +1382,37 @@ final class VarHandleByteArrayAs$Type$s extends VarHandleByteArrayBase {
             }
         }
 
+        // @Override
+        public $type$ getAndAddAcquire(Object obb, int index, $type$ delta) {
+            ByteBuffer bb = (ByteBuffer) Objects.requireNonNull(obb);
+            if (be == BE) {
+                return SCOPED_MEMORY_ACCESS.getAndAdd$RawType$Acquire(scope(bb),
+                        UNSAFE.getReference(bb, BYTE_BUFFER_HB),
+                        address(bb, indexRO(bb, index)),
+                        delta);
+            } else {
+                return getAndAddConvEndianWithCAS(bb, index, delta);
+            }
+        }
+
         @ForceInline
         static $type$ getAndAddRelease(VarHandle ob, Object obb, int index, $type$ delta) {
             ByteBufferHandle handle = (ByteBufferHandle)ob;
             ByteBuffer bb = (ByteBuffer) Objects.requireNonNull(obb);
             if (handle.be == BE) {
+                return SCOPED_MEMORY_ACCESS.getAndAdd$RawType$Release(scope(bb),
+                        UNSAFE.getReference(bb, BYTE_BUFFER_HB),
+                        address(bb, indexRO(bb, index)),
+                        delta);
+            } else {
+                return getAndAddConvEndianWithCAS(bb, index, delta);
+            }
+        }
+
+        // @Override
+        public $type$ getAndAddRelease(Object obb, int index, $type$ delta) {
+            ByteBuffer bb = (ByteBuffer) Objects.requireNonNull(obb);
+            if (be == BE) {
                 return SCOPED_MEMORY_ACCESS.getAndAdd$RawType$Release(scope(bb),
                         UNSAFE.getReference(bb, BYTE_BUFFER_HB),
                         address(bb, indexRO(bb, index)),
@@ -941,6 +1451,19 @@ final class VarHandleByteArrayAs$Type$s extends VarHandleByteArrayBase {
             }
         }
 
+        // @Override
+        public $type$ getAndBitwiseOr(Object obb, int index, $type$ value) {
+            ByteBuffer bb = (ByteBuffer) Objects.requireNonNull(obb);
+            if (be == BE) {
+                return SCOPED_MEMORY_ACCESS.getAndBitwiseOr$RawType$(scope(bb),
+                        UNSAFE.getReference(bb, BYTE_BUFFER_HB),
+                        address(bb, indexRO(bb, index)),
+                        value);
+            } else {
+                return getAndBitwiseOrConvEndianWithCAS(bb, index, value);
+            }
+        }
+
         @ForceInline
         static $type$ getAndBitwiseOrRelease(VarHandle ob, Object obb, int index, $type$ value) {
             ByteBufferHandle handle = (ByteBufferHandle)ob;
@@ -955,11 +1478,37 @@ final class VarHandleByteArrayAs$Type$s extends VarHandleByteArrayBase {
             }
         }
 
+        // @Override
+        public $type$ getAndBitwiseOrRelease(Object obb, int index, $type$ value) {
+            ByteBuffer bb = (ByteBuffer) Objects.requireNonNull(obb);
+            if (be == BE) {
+                return SCOPED_MEMORY_ACCESS.getAndBitwiseOr$RawType$Release(scope(bb),
+                        UNSAFE.getReference(bb, BYTE_BUFFER_HB),
+                        address(bb, indexRO(bb, index)),
+                        value);
+            } else {
+                return getAndBitwiseOrConvEndianWithCAS(bb, index, value);
+            }
+        }
+
         @ForceInline
         static $type$ getAndBitwiseOrAcquire(VarHandle ob, Object obb, int index, $type$ value) {
             ByteBufferHandle handle = (ByteBufferHandle)ob;
             ByteBuffer bb = (ByteBuffer) Objects.requireNonNull(obb);
             if (handle.be == BE) {
+                return SCOPED_MEMORY_ACCESS.getAndBitwiseOr$RawType$Acquire(scope(bb),
+                        UNSAFE.getReference(bb, BYTE_BUFFER_HB),
+                        address(bb, indexRO(bb, index)),
+                        value);
+            } else {
+                return getAndBitwiseOrConvEndianWithCAS(bb, index, value);
+            }
+        }
+
+        // @Override
+        public $type$ getAndBitwiseOrAcquire(Object obb, int index, $type$ value) {
+            ByteBuffer bb = (ByteBuffer) Objects.requireNonNull(obb);
+            if (be == BE) {
                 return SCOPED_MEMORY_ACCESS.getAndBitwiseOr$RawType$Acquire(scope(bb),
                         UNSAFE.getReference(bb, BYTE_BUFFER_HB),
                         address(bb, indexRO(bb, index)),
@@ -996,6 +1545,19 @@ final class VarHandleByteArrayAs$Type$s extends VarHandleByteArrayBase {
             }
         }
 
+        // @Override
+        public $type$ getAndBitwiseAnd(Object obb, int index, $type$ value) {
+            ByteBuffer bb = (ByteBuffer) Objects.requireNonNull(obb);
+            if (be == BE) {
+                return SCOPED_MEMORY_ACCESS.getAndBitwiseAnd$RawType$(scope(bb),
+                        UNSAFE.getReference(bb, BYTE_BUFFER_HB),
+                        address(bb, indexRO(bb, index)),
+                        value);
+            } else {
+                return getAndBitwiseAndConvEndianWithCAS(bb, index, value);
+            }
+        }
+
         @ForceInline
         static $type$ getAndBitwiseAndRelease(VarHandle ob, Object obb, int index, $type$ value) {
             ByteBufferHandle handle = (ByteBufferHandle)ob;
@@ -1010,11 +1572,37 @@ final class VarHandleByteArrayAs$Type$s extends VarHandleByteArrayBase {
             }
         }
 
+        // @Override
+        public $type$ getAndBitwiseAndRelease(Object obb, int index, $type$ value) {
+            ByteBuffer bb = (ByteBuffer) Objects.requireNonNull(obb);
+            if (be == BE) {
+                return SCOPED_MEMORY_ACCESS.getAndBitwiseAnd$RawType$Release(scope(bb),
+                        UNSAFE.getReference(bb, BYTE_BUFFER_HB),
+                        address(bb, indexRO(bb, index)),
+                        value);
+            } else {
+                return getAndBitwiseAndConvEndianWithCAS(bb, index, value);
+            }
+        }
+
         @ForceInline
         static $type$ getAndBitwiseAndAcquire(VarHandle ob, Object obb, int index, $type$ value) {
             ByteBufferHandle handle = (ByteBufferHandle)ob;
             ByteBuffer bb = (ByteBuffer) Objects.requireNonNull(obb);
             if (handle.be == BE) {
+                return SCOPED_MEMORY_ACCESS.getAndBitwiseAnd$RawType$Acquire(scope(bb),
+                        UNSAFE.getReference(bb, BYTE_BUFFER_HB),
+                        address(bb, indexRO(bb, index)),
+                        value);
+            } else {
+                return getAndBitwiseAndConvEndianWithCAS(bb, index, value);
+            }
+        }
+
+        // @Override
+        public $type$ getAndBitwiseAndAcquire(Object obb, int index, $type$ value) {
+            ByteBuffer bb = (ByteBuffer) Objects.requireNonNull(obb);
+            if (be == BE) {
                 return SCOPED_MEMORY_ACCESS.getAndBitwiseAnd$RawType$Acquire(scope(bb),
                         UNSAFE.getReference(bb, BYTE_BUFFER_HB),
                         address(bb, indexRO(bb, index)),
@@ -1052,6 +1640,19 @@ final class VarHandleByteArrayAs$Type$s extends VarHandleByteArrayBase {
             }
         }
 
+        // @Override
+        public $type$ getAndBitwiseXor(Object obb, int index, $type$ value) {
+            ByteBuffer bb = (ByteBuffer) Objects.requireNonNull(obb);
+            if (be == BE) {
+                return SCOPED_MEMORY_ACCESS.getAndBitwiseXor$RawType$(scope(bb),
+                        UNSAFE.getReference(bb, BYTE_BUFFER_HB),
+                        address(bb, indexRO(bb, index)),
+                        value);
+            } else {
+                return getAndBitwiseXorConvEndianWithCAS(bb, index, value);
+            }
+        }
+
         @ForceInline
         static $type$ getAndBitwiseXorRelease(VarHandle ob, Object obb, int index, $type$ value) {
             ByteBufferHandle handle = (ByteBufferHandle)ob;
@@ -1066,11 +1667,37 @@ final class VarHandleByteArrayAs$Type$s extends VarHandleByteArrayBase {
             }
         }
 
+        // @Override
+        public $type$ getAndBitwiseXorRelease(Object obb, int index, $type$ value) {
+            ByteBuffer bb = (ByteBuffer) Objects.requireNonNull(obb);
+            if (be == BE) {
+                return SCOPED_MEMORY_ACCESS.getAndBitwiseXor$RawType$Release(scope(bb),
+                        UNSAFE.getReference(bb, BYTE_BUFFER_HB),
+                        address(bb, indexRO(bb, index)),
+                        value);
+            } else {
+                return getAndBitwiseXorConvEndianWithCAS(bb, index, value);
+            }
+        }
+
         @ForceInline
         static $type$ getAndBitwiseXorAcquire(VarHandle ob, Object obb, int index, $type$ value) {
             ByteBufferHandle handle = (ByteBufferHandle)ob;
             ByteBuffer bb = (ByteBuffer) Objects.requireNonNull(obb);
             if (handle.be == BE) {
+                return SCOPED_MEMORY_ACCESS.getAndBitwiseXor$RawType$Acquire(scope(bb),
+                        UNSAFE.getReference(bb, BYTE_BUFFER_HB),
+                        address(bb, indexRO(bb, index)),
+                        value);
+            } else {
+                return getAndBitwiseXorConvEndianWithCAS(bb, index, value);
+            }
+        }
+
+        // @Override
+        public $type$ getAndBitwiseXorAcquire(Object obb, int index, $type$ value) {
+            ByteBuffer bb = (ByteBuffer) Objects.requireNonNull(obb);
+            if (be == BE) {
                 return SCOPED_MEMORY_ACCESS.getAndBitwiseXor$RawType$Acquire(scope(bb),
                         UNSAFE.getReference(bb, BYTE_BUFFER_HB),
                         address(bb, indexRO(bb, index)),

--- a/java.base/src/main/java/java/lang/invoke/X-VarHandleByteArrayView.java.template
+++ b/java.base/src/main/java/java/lang/invoke/X-VarHandleByteArrayView.java.template
@@ -39,10 +39,13 @@ import java.util.List;
 import java.util.Objects;
 import java.util.function.BiFunction;
 
+import org.qbicc.rt.annotation.Tracking;
+
 import static java.lang.invoke.MethodHandleStatics.UNSAFE;
 
 #warn
 
+@Tracking("src/java.base/share/classes/java/lang/invoke/X-VarHandleByteArrayView.java.template")
 final class VarHandleByteArrayAs$Type$s extends VarHandleByteArrayBase {
 
     static final JavaNioAccess NIO_ACCESS = SharedSecrets.getJavaNioAccess();

--- a/java.base/src/main/java/java/lang/invoke/X-VarHandleMemoryAccess.java.template
+++ b/java.base/src/main/java/java/lang/invoke/X-VarHandleMemoryAccess.java.template
@@ -1,0 +1,579 @@
+/*
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package java.lang.invoke;
+
+import jdk.internal.access.foreign.MemorySegmentProxy;
+import jdk.internal.misc.ScopedMemoryAccess;
+import jdk.internal.vm.annotation.ForceInline;
+
+import java.lang.ref.Reference;
+
+import java.util.Objects;
+
+import static java.lang.invoke.MethodHandleStatics.UNSAFE;
+
+#warn
+
+final class MemoryAccessVarHandle$Type$Helper extends MemoryAccessVarHandleBase {
+
+    static final boolean BE = UNSAFE.isBigEndian();
+
+    static final ScopedMemoryAccess SCOPED_MEMORY_ACCESS = ScopedMemoryAccess.getScopedMemoryAccess();
+
+    static final int VM_ALIGN = $BoxType$.BYTES - 1;
+
+    static final VarForm FORM = new VarForm(MemoryAccessVarHandle$Type$Helper.class, MemorySegmentProxy.class, $type$.class, long.class);
+
+    MemoryAccessVarHandle$Type$Helper(boolean skipAlignmentMaskCheck, boolean be, long length, long alignmentMask, boolean exact) {
+        super(FORM, skipAlignmentMaskCheck, be, length, alignmentMask, exact);
+    }
+
+    @Override
+    final MethodType accessModeTypeUncached(VarHandle.AccessType accessType) {
+        return accessType.accessModeType(MemorySegmentProxy.class, $type$.class, long.class);
+    }
+
+    @Override
+    public MemoryAccessVarHandle$Type$Helper withInvokeExactBehavior() {
+        return hasInvokeExactBehavior() ?
+                this :
+                new MemoryAccessVarHandle$Type$Helper(skipAlignmentMaskCheck, be, length, alignmentMask, true);
+    }
+
+    @Override
+    public MemoryAccessVarHandle$Type$Helper withInvokeBehavior() {
+        return !hasInvokeExactBehavior() ?
+                this :
+                new MemoryAccessVarHandle$Type$Helper(skipAlignmentMaskCheck, be, length, alignmentMask, false);
+    }
+
+#if[floatingPoint]
+    @ForceInline
+    static $rawType$ convEndian(boolean big, $type$ v) {
+        $rawType$ rv = $Type$.$type$ToRaw$RawType$Bits(v);
+        return big == BE ? rv : $RawBoxType$.reverseBytes(rv);
+    }
+
+    @ForceInline
+    static $type$ convEndian(boolean big, $rawType$ rv) {
+        rv = big == BE ? rv : $RawBoxType$.reverseBytes(rv);
+        return $Type$.$rawType$BitsTo$Type$(rv);
+    }
+#else[floatingPoint]
+#if[byte]
+    @ForceInline
+    static $type$ convEndian(boolean big, $type$ n) {
+        return n;
+    }
+#else[byte]
+    @ForceInline
+    static $type$ convEndian(boolean big, $type$ n) {
+        return big == BE ? n : $BoxType$.reverseBytes(n);
+    }
+#end[byte]
+#end[floatingPoint]
+
+    @ForceInline
+    static MemorySegmentProxy checkAddress(Object obb, long offset, long length, boolean ro) {
+        MemorySegmentProxy oo = (MemorySegmentProxy)Objects.requireNonNull(obb);
+        oo.checkAccess(offset, length, ro);
+        return oo;
+    }
+
+    @ForceInline
+    static long offset(boolean skipAlignmentMaskCheck, MemorySegmentProxy bb, long offset, long alignmentMask) {
+        long address = offsetNoVMAlignCheck(skipAlignmentMaskCheck, bb, offset, alignmentMask);
+        if ((address & VM_ALIGN) != 0) {
+            throw MemoryAccessVarHandleBase.newIllegalStateExceptionForMisalignedAccess(address);
+        }
+        return address;
+    }
+
+    @ForceInline
+    static long offsetNoVMAlignCheck(boolean skipAlignmentMaskCheck, MemorySegmentProxy bb, long offset, long alignmentMask) {
+        long base = bb.unsafeGetOffset();
+        long address = base + offset;
+        if (skipAlignmentMaskCheck) {
+            //note: the offset portion has already been aligned-checked, by construction
+            if ((base & alignmentMask) != 0) {
+                throw MemoryAccessVarHandleBase.newIllegalStateExceptionForMisalignedAccess(address);
+            }
+        } else {
+            if ((address & alignmentMask) != 0) {
+                throw MemoryAccessVarHandleBase.newIllegalStateExceptionForMisalignedAccess(address);
+            }
+        }
+        return address;
+    }
+
+    @ForceInline
+    static $type$ get(VarHandle ob, Object obb, long base) {
+        MemoryAccessVarHandleBase handle = (MemoryAccessVarHandleBase)ob;
+        MemorySegmentProxy bb = checkAddress(obb, base, handle.length, true);
+#if[floatingPoint]
+        $rawType$ rawValue = SCOPED_MEMORY_ACCESS.get$RawType$Unaligned(bb.scope(),
+                bb.unsafeGetBase(),
+                offsetNoVMAlignCheck(handle.skipAlignmentMaskCheck, bb, base, handle.alignmentMask),
+                handle.be);
+        return $Type$.$rawType$BitsTo$Type$(rawValue);
+#else[floatingPoint]
+#if[byte]
+        return SCOPED_MEMORY_ACCESS.get$Type$(bb.scope(),
+                bb.unsafeGetBase(),
+                offsetNoVMAlignCheck(handle.skipAlignmentMaskCheck, bb, base, handle.alignmentMask));
+#else[byte]
+        return SCOPED_MEMORY_ACCESS.get$Type$Unaligned(bb.scope(),
+                bb.unsafeGetBase(),
+                offsetNoVMAlignCheck(handle.skipAlignmentMaskCheck, bb, base, handle.alignmentMask),
+                handle.be);
+#end[byte]
+#end[floatingPoint]
+    }
+
+    @ForceInline
+    static void set(VarHandle ob, Object obb, long base, $type$ value) {
+        MemoryAccessVarHandleBase handle = (MemoryAccessVarHandleBase)ob;
+        MemorySegmentProxy bb = checkAddress(obb, base, handle.length, false);
+#if[floatingPoint]
+        SCOPED_MEMORY_ACCESS.put$RawType$Unaligned(bb.scope(),
+                bb.unsafeGetBase(),
+                offsetNoVMAlignCheck(handle.skipAlignmentMaskCheck, bb, base, handle.alignmentMask),
+                $Type$.$type$ToRaw$RawType$Bits(value),
+                handle.be);
+#else[floatingPoint]
+#if[byte]
+        SCOPED_MEMORY_ACCESS.put$Type$(bb.scope(),
+                bb.unsafeGetBase(),
+                offsetNoVMAlignCheck(handle.skipAlignmentMaskCheck, bb, base, handle.alignmentMask),
+                value);
+#else[byte]
+        SCOPED_MEMORY_ACCESS.put$Type$Unaligned(bb.scope(),
+                bb.unsafeGetBase(),
+                offsetNoVMAlignCheck(handle.skipAlignmentMaskCheck, bb, base, handle.alignmentMask),
+                value,
+                handle.be);
+#end[byte]
+#end[floatingPoint]
+    }
+
+    @ForceInline
+    static $type$ getVolatile(VarHandle ob, Object obb, long base) {
+        MemoryAccessVarHandleBase handle = (MemoryAccessVarHandleBase)ob;
+        MemorySegmentProxy bb = checkAddress(obb, base, handle.length, true);
+        return convEndian(handle.be,
+                          SCOPED_MEMORY_ACCESS.get$RawType$Volatile(bb.scope(),
+                                  bb.unsafeGetBase(),
+                                  offset(handle.skipAlignmentMaskCheck, bb, base, handle.alignmentMask)));
+    }
+
+    @ForceInline
+    static void setVolatile(VarHandle ob, Object obb, long base, $type$ value) {
+        MemoryAccessVarHandleBase handle = (MemoryAccessVarHandleBase)ob;
+        MemorySegmentProxy bb = checkAddress(obb, base, handle.length, false);
+        SCOPED_MEMORY_ACCESS.put$RawType$Volatile(bb.scope(),
+                bb.unsafeGetBase(),
+                offset(handle.skipAlignmentMaskCheck, bb, base, handle.alignmentMask),
+                convEndian(handle.be, value));
+    }
+
+    @ForceInline
+    static $type$ getAcquire(VarHandle ob, Object obb, long base) {
+        MemoryAccessVarHandleBase handle = (MemoryAccessVarHandleBase)ob;
+        MemorySegmentProxy bb = checkAddress(obb, base, handle.length, true);
+        return convEndian(handle.be,
+                          SCOPED_MEMORY_ACCESS.get$RawType$Acquire(bb.scope(),
+                                  bb.unsafeGetBase(),
+                                  offset(handle.skipAlignmentMaskCheck, bb, base, handle.alignmentMask)));
+    }
+
+    @ForceInline
+    static void setRelease(VarHandle ob, Object obb, long base, $type$ value) {
+        MemoryAccessVarHandleBase handle = (MemoryAccessVarHandleBase)ob;
+        MemorySegmentProxy bb = checkAddress(obb, base, handle.length, false);
+        SCOPED_MEMORY_ACCESS.put$RawType$Release(bb.scope(),
+                bb.unsafeGetBase(),
+                offset(handle.skipAlignmentMaskCheck, bb, base, handle.alignmentMask),
+                convEndian(handle.be, value));
+    }
+
+    @ForceInline
+    static $type$ getOpaque(VarHandle ob, Object obb, long base) {
+        MemoryAccessVarHandleBase handle = (MemoryAccessVarHandleBase)ob;
+        MemorySegmentProxy bb = checkAddress(obb, base, handle.length, true);
+        return convEndian(handle.be,
+                          SCOPED_MEMORY_ACCESS.get$RawType$Opaque(bb.scope(),
+                                  bb.unsafeGetBase(),
+                                  offset(handle.skipAlignmentMaskCheck, bb, base, handle.alignmentMask)));
+    }
+
+    @ForceInline
+    static void setOpaque(VarHandle ob, Object obb, long base, $type$ value) {
+        MemoryAccessVarHandleBase handle = (MemoryAccessVarHandleBase)ob;
+        MemorySegmentProxy bb = checkAddress(obb, base, handle.length, false);
+        SCOPED_MEMORY_ACCESS.put$RawType$Opaque(bb.scope(),
+                bb.unsafeGetBase(),
+                offset(handle.skipAlignmentMaskCheck, bb, base, handle.alignmentMask),
+                convEndian(handle.be, value));
+    }
+#if[CAS]
+
+    @ForceInline
+    static boolean compareAndSet(VarHandle ob, Object obb, long base, $type$ expected, $type$ value) {
+        MemoryAccessVarHandleBase handle = (MemoryAccessVarHandleBase)ob;
+        MemorySegmentProxy bb = checkAddress(obb, base, handle.length, false);
+        return SCOPED_MEMORY_ACCESS.compareAndSet$RawType$(bb.scope(),
+                bb.unsafeGetBase(),
+                offset(handle.skipAlignmentMaskCheck, bb, base, handle.alignmentMask),
+                convEndian(handle.be, expected), convEndian(handle.be, value));
+    }
+
+    @ForceInline
+    static $type$ compareAndExchange(VarHandle ob, Object obb, long base, $type$ expected, $type$ value) {
+        MemoryAccessVarHandleBase handle = (MemoryAccessVarHandleBase)ob;
+        MemorySegmentProxy bb = checkAddress(obb, base, handle.length, false);
+        return convEndian(handle.be,
+                          SCOPED_MEMORY_ACCESS.compareAndExchange$RawType$(bb.scope(),
+                                  bb.unsafeGetBase(),
+                                  offset(handle.skipAlignmentMaskCheck, bb, base, handle.alignmentMask),
+                                  convEndian(handle.be, expected), convEndian(handle.be, value)));
+    }
+
+    @ForceInline
+    static $type$ compareAndExchangeAcquire(VarHandle ob, Object obb, long base, $type$ expected, $type$ value) {
+        MemoryAccessVarHandleBase handle = (MemoryAccessVarHandleBase)ob;
+        MemorySegmentProxy bb = checkAddress(obb, base, handle.length, false);
+        return convEndian(handle.be,
+                          SCOPED_MEMORY_ACCESS.compareAndExchange$RawType$Acquire(bb.scope(),
+                                  bb.unsafeGetBase(),
+                                  offset(handle.skipAlignmentMaskCheck, bb, base, handle.alignmentMask),
+                                  convEndian(handle.be, expected), convEndian(handle.be, value)));
+    }
+
+    @ForceInline
+    static $type$ compareAndExchangeRelease(VarHandle ob, Object obb, long base, $type$ expected, $type$ value) {
+        MemoryAccessVarHandleBase handle = (MemoryAccessVarHandleBase)ob;
+        MemorySegmentProxy bb = checkAddress(obb, base, handle.length, false);
+        return convEndian(handle.be,
+                          SCOPED_MEMORY_ACCESS.compareAndExchange$RawType$Release(bb.scope(),
+                                  bb.unsafeGetBase(),
+                                  offset(handle.skipAlignmentMaskCheck, bb, base, handle.alignmentMask),
+                                  convEndian(handle.be, expected), convEndian(handle.be, value)));
+    }
+
+    @ForceInline
+    static boolean weakCompareAndSetPlain(VarHandle ob, Object obb, long base, $type$ expected, $type$ value) {
+        MemoryAccessVarHandleBase handle = (MemoryAccessVarHandleBase)ob;
+        MemorySegmentProxy bb = checkAddress(obb, base, handle.length, false);
+        return SCOPED_MEMORY_ACCESS.weakCompareAndSet$RawType$Plain(bb.scope(),
+                bb.unsafeGetBase(),
+                offset(handle.skipAlignmentMaskCheck, bb, base, handle.alignmentMask),
+                convEndian(handle.be, expected), convEndian(handle.be, value));
+    }
+
+    @ForceInline
+    static boolean weakCompareAndSet(VarHandle ob, Object obb, long base, $type$ expected, $type$ value) {
+        MemoryAccessVarHandleBase handle = (MemoryAccessVarHandleBase)ob;
+        MemorySegmentProxy bb = checkAddress(obb, base, handle.length, false);
+        return SCOPED_MEMORY_ACCESS.weakCompareAndSet$RawType$(bb.scope(),
+                bb.unsafeGetBase(),
+                offset(handle.skipAlignmentMaskCheck, bb, base, handle.alignmentMask),
+                convEndian(handle.be, expected), convEndian(handle.be, value));
+    }
+
+    @ForceInline
+    static boolean weakCompareAndSetAcquire(VarHandle ob, Object obb, long base, $type$ expected, $type$ value) {
+        MemoryAccessVarHandleBase handle = (MemoryAccessVarHandleBase)ob;
+        MemorySegmentProxy bb = checkAddress(obb, base, handle.length, false);
+        return SCOPED_MEMORY_ACCESS.weakCompareAndSet$RawType$Acquire(bb.scope(),
+                bb.unsafeGetBase(),
+                offset(handle.skipAlignmentMaskCheck, bb, base, handle.alignmentMask),
+                convEndian(handle.be, expected), convEndian(handle.be, value));
+    }
+
+    @ForceInline
+    static boolean weakCompareAndSetRelease(VarHandle ob, Object obb, long base, $type$ expected, $type$ value) {
+        MemoryAccessVarHandleBase handle = (MemoryAccessVarHandleBase)ob;
+        MemorySegmentProxy bb = checkAddress(obb, base, handle.length, false);
+        return SCOPED_MEMORY_ACCESS.weakCompareAndSet$RawType$Release(bb.scope(),
+                bb.unsafeGetBase(),
+                offset(handle.skipAlignmentMaskCheck, bb, base, handle.alignmentMask),
+                convEndian(handle.be, expected), convEndian(handle.be, value));
+    }
+
+    @ForceInline
+    static $type$ getAndSet(VarHandle ob, Object obb, long base, $type$ value) {
+        MemoryAccessVarHandleBase handle = (MemoryAccessVarHandleBase)ob;
+        MemorySegmentProxy bb = checkAddress(obb, base, handle.length, false);
+        return convEndian(handle.be,
+                          SCOPED_MEMORY_ACCESS.getAndSet$RawType$(bb.scope(),
+                                  bb.unsafeGetBase(),
+                                  offset(handle.skipAlignmentMaskCheck, bb, base, handle.alignmentMask),
+                                  convEndian(handle.be, value)));
+    }
+
+    @ForceInline
+    static $type$ getAndSetAcquire(VarHandle ob, Object obb, long base, $type$ value) {
+        MemoryAccessVarHandleBase handle = (MemoryAccessVarHandleBase)ob;
+        MemorySegmentProxy bb = checkAddress(obb, base, handle.length, false);
+        return convEndian(handle.be,
+                          SCOPED_MEMORY_ACCESS.getAndSet$RawType$Acquire(bb.scope(),
+                                  bb.unsafeGetBase(),
+                                  offset(handle.skipAlignmentMaskCheck, bb, base, handle.alignmentMask),
+                                  convEndian(handle.be, value)));
+    }
+
+    @ForceInline
+    static $type$ getAndSetRelease(VarHandle ob, Object obb, long base, $type$ value) {
+        MemoryAccessVarHandleBase handle = (MemoryAccessVarHandleBase)ob;
+        MemorySegmentProxy bb = checkAddress(obb, base, handle.length, false);
+        return convEndian(handle.be,
+                          SCOPED_MEMORY_ACCESS.getAndSet$RawType$Release(bb.scope(),
+                                  bb.unsafeGetBase(),
+                                  offset(handle.skipAlignmentMaskCheck, bb, base, handle.alignmentMask),
+                                  convEndian(handle.be, value)));
+    }
+#end[CAS]
+#if[AtomicAdd]
+
+    @ForceInline
+    static $type$ getAndAdd(VarHandle ob, Object obb, long base, $type$ delta) {
+        MemoryAccessVarHandleBase handle = (MemoryAccessVarHandleBase)ob;
+        MemorySegmentProxy bb = checkAddress(obb, base, handle.length, false);
+        if (handle.be == BE) {
+            return SCOPED_MEMORY_ACCESS.getAndAdd$RawType$(bb.scope(),
+                    bb.unsafeGetBase(),
+                    offset(handle.skipAlignmentMaskCheck, bb, base, handle.alignmentMask),
+                    delta);
+        } else {
+            return getAndAddConvEndianWithCAS(bb, offset(handle.skipAlignmentMaskCheck, bb, base, handle.alignmentMask), delta);
+        }
+    }
+
+    @ForceInline
+    static $type$ getAndAddAcquire(VarHandle ob, Object obb, long base, $type$ delta) {
+        MemoryAccessVarHandleBase handle = (MemoryAccessVarHandleBase)ob;
+        MemorySegmentProxy bb = checkAddress(obb, base, handle.length, false);
+        if (handle.be == BE) {
+            return SCOPED_MEMORY_ACCESS.getAndAdd$RawType$Acquire(bb.scope(),
+                    bb.unsafeGetBase(),
+                    offset(handle.skipAlignmentMaskCheck, bb, base, handle.alignmentMask),
+                    delta);
+        } else {
+            return getAndAddConvEndianWithCAS(bb, offset(handle.skipAlignmentMaskCheck, bb, base, handle.alignmentMask), delta);
+        }
+    }
+
+    @ForceInline
+    static $type$ getAndAddRelease(VarHandle ob, Object obb, long base, $type$ delta) {
+        MemoryAccessVarHandleBase handle = (MemoryAccessVarHandleBase)ob;
+        MemorySegmentProxy bb = checkAddress(obb, base, handle.length, false);
+        if (handle.be == BE) {
+            return SCOPED_MEMORY_ACCESS.getAndAdd$RawType$Release(bb.scope(),
+                    bb.unsafeGetBase(),
+                    offset(handle.skipAlignmentMaskCheck, bb, base, handle.alignmentMask),
+                    delta);
+        } else {
+            return getAndAddConvEndianWithCAS(bb, offset(handle.skipAlignmentMaskCheck, bb, base, handle.alignmentMask), delta);
+        }
+    }
+
+    @ForceInline
+    static $type$ getAndAddConvEndianWithCAS(MemorySegmentProxy bb, long offset, $type$ delta) {
+        $type$ nativeExpectedValue, expectedValue;
+        Object base = bb.unsafeGetBase();
+        do {
+            nativeExpectedValue = SCOPED_MEMORY_ACCESS.get$RawType$Volatile(bb.scope(),base, offset);
+            expectedValue = $RawBoxType$.reverseBytes(nativeExpectedValue);
+        } while (!SCOPED_MEMORY_ACCESS.weakCompareAndSet$RawType$(bb.scope(),base, offset,
+                nativeExpectedValue, $RawBoxType$.reverseBytes(expectedValue + delta)));
+        return expectedValue;
+    }
+#end[AtomicAdd]
+#if[Bitwise]
+
+    @ForceInline
+    static $type$ getAndBitwiseOr(VarHandle ob, Object obb, long base, $type$ value) {
+        MemoryAccessVarHandleBase handle = (MemoryAccessVarHandleBase)ob;
+        MemorySegmentProxy bb = checkAddress(obb, base, handle.length, false);
+        if (handle.be == BE) {
+            return SCOPED_MEMORY_ACCESS.getAndBitwiseOr$RawType$(bb.scope(),
+                    bb.unsafeGetBase(),
+                    offset(handle.skipAlignmentMaskCheck, bb, base, handle.alignmentMask),
+                    value);
+        } else {
+            return getAndBitwiseOrConvEndianWithCAS(bb, offset(handle.skipAlignmentMaskCheck, bb, base, handle.alignmentMask), value);
+        }
+    }
+
+    @ForceInline
+    static $type$ getAndBitwiseOrRelease(VarHandle ob, Object obb, long base, $type$ value) {
+        MemoryAccessVarHandleBase handle = (MemoryAccessVarHandleBase)ob;
+        MemorySegmentProxy bb = checkAddress(obb, base, handle.length, false);
+        if (handle.be == BE) {
+            return SCOPED_MEMORY_ACCESS.getAndBitwiseOr$RawType$Release(bb.scope(),
+                    bb.unsafeGetBase(),
+                    offset(handle.skipAlignmentMaskCheck, bb, base, handle.alignmentMask),
+                    value);
+        } else {
+            return getAndBitwiseOrConvEndianWithCAS(bb, offset(handle.skipAlignmentMaskCheck, bb, base, handle.alignmentMask), value);
+        }
+    }
+
+    @ForceInline
+    static $type$ getAndBitwiseOrAcquire(VarHandle ob, Object obb, long base, $type$ value) {
+        MemoryAccessVarHandleBase handle = (MemoryAccessVarHandleBase)ob;
+        MemorySegmentProxy bb = checkAddress(obb, base, handle.length, false);
+        if (handle.be == BE) {
+            return SCOPED_MEMORY_ACCESS.getAndBitwiseOr$RawType$Acquire(bb.scope(),
+                    bb.unsafeGetBase(),
+                    offset(handle.skipAlignmentMaskCheck, bb, base, handle.alignmentMask),
+                    value);
+        } else {
+            return getAndBitwiseOrConvEndianWithCAS(bb, offset(handle.skipAlignmentMaskCheck, bb, base, handle.alignmentMask), value);
+        }
+    }
+
+    @ForceInline
+    static $type$ getAndBitwiseOrConvEndianWithCAS(MemorySegmentProxy bb, long offset, $type$ value) {
+        $type$ nativeExpectedValue, expectedValue;
+        Object base = bb.unsafeGetBase();
+        do {
+            nativeExpectedValue = SCOPED_MEMORY_ACCESS.get$RawType$Volatile(bb.scope(),base, offset);
+            expectedValue = $RawBoxType$.reverseBytes(nativeExpectedValue);
+        } while (!SCOPED_MEMORY_ACCESS.weakCompareAndSet$RawType$(bb.scope(),base, offset,
+                nativeExpectedValue, $RawBoxType$.reverseBytes(expectedValue | value)));
+        return expectedValue;
+    }
+
+    @ForceInline
+    static $type$ getAndBitwiseAnd(VarHandle ob, Object obb, long base, $type$ value) {
+        MemoryAccessVarHandleBase handle = (MemoryAccessVarHandleBase)ob;
+        MemorySegmentProxy bb = checkAddress(obb, base, handle.length, false);
+        if (handle.be == BE) {
+            return SCOPED_MEMORY_ACCESS.getAndBitwiseAnd$RawType$(bb.scope(),
+                    bb.unsafeGetBase(),
+                    offset(handle.skipAlignmentMaskCheck, bb, base, handle.alignmentMask),
+                    value);
+        } else {
+            return getAndBitwiseAndConvEndianWithCAS(bb, offset(handle.skipAlignmentMaskCheck, bb, base, handle.alignmentMask), value);
+        }
+    }
+
+    @ForceInline
+    static $type$ getAndBitwiseAndRelease(VarHandle ob, Object obb, long base, $type$ value) {
+        MemoryAccessVarHandleBase handle = (MemoryAccessVarHandleBase)ob;
+        MemorySegmentProxy bb = checkAddress(obb, base, handle.length, false);
+        if (handle.be == BE) {
+            return SCOPED_MEMORY_ACCESS.getAndBitwiseAnd$RawType$Release(bb.scope(),
+                    bb.unsafeGetBase(),
+                    offset(handle.skipAlignmentMaskCheck, bb, base, handle.alignmentMask),
+                    value);
+        } else {
+            return getAndBitwiseAndConvEndianWithCAS(bb, offset(handle.skipAlignmentMaskCheck, bb, base, handle.alignmentMask), value);
+        }
+    }
+
+    @ForceInline
+    static $type$ getAndBitwiseAndAcquire(VarHandle ob, Object obb, long base, $type$ value) {
+        MemoryAccessVarHandleBase handle = (MemoryAccessVarHandleBase)ob;
+        MemorySegmentProxy bb = checkAddress(obb, base, handle.length, false);
+        if (handle.be == BE) {
+            return SCOPED_MEMORY_ACCESS.getAndBitwiseAnd$RawType$Acquire(bb.scope(),
+                    bb.unsafeGetBase(),
+                    offset(handle.skipAlignmentMaskCheck, bb, base, handle.alignmentMask),
+                    value);
+        } else {
+            return getAndBitwiseAndConvEndianWithCAS(bb, offset(handle.skipAlignmentMaskCheck, bb, base, handle.alignmentMask), value);
+        }
+    }
+
+    @ForceInline
+    static $type$ getAndBitwiseAndConvEndianWithCAS(MemorySegmentProxy bb, long offset, $type$ value) {
+        $type$ nativeExpectedValue, expectedValue;
+        Object base = bb.unsafeGetBase();
+        do {
+            nativeExpectedValue = SCOPED_MEMORY_ACCESS.get$RawType$Volatile(bb.scope(),base, offset);
+            expectedValue = $RawBoxType$.reverseBytes(nativeExpectedValue);
+        } while (!SCOPED_MEMORY_ACCESS.weakCompareAndSet$RawType$(bb.scope(),base, offset,
+                nativeExpectedValue, $RawBoxType$.reverseBytes(expectedValue & value)));
+        return expectedValue;
+    }
+
+
+    @ForceInline
+    static $type$ getAndBitwiseXor(VarHandle ob, Object obb, long base, $type$ value) {
+        MemoryAccessVarHandleBase handle = (MemoryAccessVarHandleBase)ob;
+        MemorySegmentProxy bb = checkAddress(obb, base, handle.length, false);
+        if (handle.be == BE) {
+            return SCOPED_MEMORY_ACCESS.getAndBitwiseXor$RawType$(bb.scope(),
+                    bb.unsafeGetBase(),
+                    offset(handle.skipAlignmentMaskCheck, bb, base, handle.alignmentMask),
+                    value);
+        } else {
+            return getAndBitwiseXorConvEndianWithCAS(bb, offset(handle.skipAlignmentMaskCheck, bb, base, handle.alignmentMask), value);
+        }
+    }
+
+    @ForceInline
+    static $type$ getAndBitwiseXorRelease(VarHandle ob, Object obb, long base, $type$ value) {
+        MemoryAccessVarHandleBase handle = (MemoryAccessVarHandleBase)ob;
+        MemorySegmentProxy bb = checkAddress(obb, base, handle.length, false);
+        if (handle.be == BE) {
+            return SCOPED_MEMORY_ACCESS.getAndBitwiseXor$RawType$Release(bb.scope(),
+                    bb.unsafeGetBase(),
+                    offset(handle.skipAlignmentMaskCheck, bb, base, handle.alignmentMask),
+                    value);
+        } else {
+            return getAndBitwiseXorConvEndianWithCAS(bb, offset(handle.skipAlignmentMaskCheck, bb, base, handle.alignmentMask), value);
+        }
+    }
+
+    @ForceInline
+    static $type$ getAndBitwiseXorAcquire(VarHandle ob, Object obb, long base, $type$ value) {
+        MemoryAccessVarHandleBase handle = (MemoryAccessVarHandleBase)ob;
+        MemorySegmentProxy bb = checkAddress(obb, base, handle.length, false);
+        if (handle.be == BE) {
+            return SCOPED_MEMORY_ACCESS.getAndBitwiseXor$RawType$Acquire(bb.scope(),
+                    bb.unsafeGetBase(),
+                    offset(handle.skipAlignmentMaskCheck, bb, base, handle.alignmentMask),
+                    value);
+        } else {
+            return getAndBitwiseXorConvEndianWithCAS(bb, offset(handle.skipAlignmentMaskCheck, bb, base, handle.alignmentMask), value);
+        }
+    }
+
+    @ForceInline
+    static $type$ getAndBitwiseXorConvEndianWithCAS(MemorySegmentProxy bb, long offset, $type$ value) {
+        $type$ nativeExpectedValue, expectedValue;
+        Object base = bb.unsafeGetBase();
+        do {
+            nativeExpectedValue = SCOPED_MEMORY_ACCESS.get$RawType$Volatile(bb.scope(),base, offset);
+            expectedValue = $RawBoxType$.reverseBytes(nativeExpectedValue);
+        } while (!SCOPED_MEMORY_ACCESS.weakCompareAndSet$RawType$(bb.scope(),base, offset,
+                nativeExpectedValue, $RawBoxType$.reverseBytes(expectedValue ^ value)));
+        return expectedValue;
+    }
+#end[Bitwise]
+}

--- a/java.base/src/main/java/java/lang/invoke/X-VarHandleMemoryAccess.java.template
+++ b/java.base/src/main/java/java/lang/invoke/X-VarHandleMemoryAccess.java.template
@@ -32,10 +32,13 @@ import java.lang.ref.Reference;
 
 import java.util.Objects;
 
+import org.qbicc.rt.annotation.Tracking;
+
 import static java.lang.invoke.MethodHandleStatics.UNSAFE;
 
 #warn
 
+@Tracking("src/java.base/share/classes/java/lang/invoke/X-VarHandleMemoryAccess.java.template")
 final class MemoryAccessVarHandle$Type$Helper extends MemoryAccessVarHandleBase {
 
     static final boolean BE = UNSAFE.isBigEndian();

--- a/java.base/src/main/java/java/lang/invoke/X-VarHandleMemoryAccess.java.template
+++ b/java.base/src/main/java/java/lang/invoke/X-VarHandleMemoryAccess.java.template
@@ -155,6 +155,29 @@ final class MemoryAccessVarHandle$Type$Helper extends MemoryAccessVarHandleBase 
 #end[floatingPoint]
     }
 
+    // @Override
+    public $type$ get(Object obb, long base) {
+        MemorySegmentProxy bb = checkAddress(obb, base, length, true);
+#if[floatingPoint]
+        $rawType$ rawValue = SCOPED_MEMORY_ACCESS.get$RawType$Unaligned(bb.scope(),
+                bb.unsafeGetBase(),
+                offsetNoVMAlignCheck(skipAlignmentMaskCheck, bb, base, alignmentMask),
+                be);
+        return $Type$.$rawType$BitsTo$Type$(rawValue);
+#else[floatingPoint]
+#if[byte]
+        return SCOPED_MEMORY_ACCESS.get$Type$(bb.scope(),
+                bb.unsafeGetBase(),
+                offsetNoVMAlignCheck(skipAlignmentMaskCheck, bb, base, alignmentMask));
+#else[byte]
+        return SCOPED_MEMORY_ACCESS.get$Type$Unaligned(bb.scope(),
+                bb.unsafeGetBase(),
+                offsetNoVMAlignCheck(skipAlignmentMaskCheck, bb, base, alignmentMask),
+                be);
+#end[byte]
+#end[floatingPoint]
+    }
+
     @ForceInline
     static void set(VarHandle ob, Object obb, long base, $type$ value) {
         MemoryAccessVarHandleBase handle = (MemoryAccessVarHandleBase)ob;
@@ -181,6 +204,29 @@ final class MemoryAccessVarHandle$Type$Helper extends MemoryAccessVarHandleBase 
 #end[floatingPoint]
     }
 
+    // @Override
+    public void set(Object obb, long base, $type$ value) {
+        MemorySegmentProxy bb = checkAddress(obb, base, length, false);
+#if[floatingPoint]
+        SCOPED_MEMORY_ACCESS.put$RawType$Unaligned(bb.scope(),
+                bb.unsafeGetBase(),
+                offsetNoVMAlignCheck(skipAlignmentMaskCheck, bb, base, alignmentMask),
+                $Type$.$type$ToRaw$RawType$Bits(value), be);
+#else[floatingPoint]
+#if[byte]
+        SCOPED_MEMORY_ACCESS.put$Type$(bb.scope(),
+                bb.unsafeGetBase(),
+                offsetNoVMAlignCheck(skipAlignmentMaskCheck, bb, base, alignmentMask),
+                value);
+#else[byte]
+        SCOPED_MEMORY_ACCESS.put$Type$Unaligned(bb.scope(),
+                bb.unsafeGetBase(),
+                offsetNoVMAlignCheck(skipAlignmentMaskCheck, bb, base, alignmentMask),
+                value, be);
+#end[byte]
+#end[floatingPoint]
+    }
+
     @ForceInline
     static $type$ getVolatile(VarHandle ob, Object obb, long base) {
         MemoryAccessVarHandleBase handle = (MemoryAccessVarHandleBase)ob;
@@ -189,6 +235,13 @@ final class MemoryAccessVarHandle$Type$Helper extends MemoryAccessVarHandleBase 
                           SCOPED_MEMORY_ACCESS.get$RawType$Volatile(bb.scope(),
                                   bb.unsafeGetBase(),
                                   offset(handle.skipAlignmentMaskCheck, bb, base, handle.alignmentMask)));
+    }
+
+    // @Override
+    public $type$ getVolatile(Object obb, long base) {
+        MemorySegmentProxy bb = checkAddress(obb, base, length, true);
+        return convEndian(be, SCOPED_MEMORY_ACCESS.get$RawType$Volatile(bb.scope(),
+                bb.unsafeGetBase(), offset(skipAlignmentMaskCheck, bb, base, alignmentMask)));
     }
 
     @ForceInline
@@ -201,6 +254,15 @@ final class MemoryAccessVarHandle$Type$Helper extends MemoryAccessVarHandleBase 
                 convEndian(handle.be, value));
     }
 
+    // @Override
+    public void setVolatile(Object obb, long base, $type$ value) {
+        MemorySegmentProxy bb = checkAddress(obb, base, length, false);
+        SCOPED_MEMORY_ACCESS.put$RawType$Volatile(bb.scope(),
+                bb.unsafeGetBase(),
+                offset(skipAlignmentMaskCheck, bb, base, alignmentMask),
+                convEndian(be, value));
+    }
+
     @ForceInline
     static $type$ getAcquire(VarHandle ob, Object obb, long base) {
         MemoryAccessVarHandleBase handle = (MemoryAccessVarHandleBase)ob;
@@ -209,6 +271,13 @@ final class MemoryAccessVarHandle$Type$Helper extends MemoryAccessVarHandleBase 
                           SCOPED_MEMORY_ACCESS.get$RawType$Acquire(bb.scope(),
                                   bb.unsafeGetBase(),
                                   offset(handle.skipAlignmentMaskCheck, bb, base, handle.alignmentMask)));
+    }
+
+    // @Override
+    public $type$ getAcquire(Object obb, long base) {
+        MemorySegmentProxy bb = checkAddress(obb, base, length, true);
+        return convEndian(be, SCOPED_MEMORY_ACCESS.get$RawType$Acquire(bb.scope(),
+                bb.unsafeGetBase(), offset(skipAlignmentMaskCheck, bb, base, alignmentMask)));
     }
 
     @ForceInline
@@ -221,6 +290,15 @@ final class MemoryAccessVarHandle$Type$Helper extends MemoryAccessVarHandleBase 
                 convEndian(handle.be, value));
     }
 
+    // @Override
+    public void setRelease(Object obb, long base, $type$ value) {
+        MemorySegmentProxy bb = checkAddress(obb, base, length, false);
+        SCOPED_MEMORY_ACCESS.put$RawType$Release(bb.scope(),
+                bb.unsafeGetBase(),
+                offset(skipAlignmentMaskCheck, bb, base, alignmentMask),
+                convEndian(be, value));
+    }
+
     @ForceInline
     static $type$ getOpaque(VarHandle ob, Object obb, long base) {
         MemoryAccessVarHandleBase handle = (MemoryAccessVarHandleBase)ob;
@@ -231,6 +309,13 @@ final class MemoryAccessVarHandle$Type$Helper extends MemoryAccessVarHandleBase 
                                   offset(handle.skipAlignmentMaskCheck, bb, base, handle.alignmentMask)));
     }
 
+    // @Override
+    public $type$ getOpaque(Object obb, long base) {
+        MemorySegmentProxy bb = checkAddress(obb, base, length, true);
+        return convEndian(be, SCOPED_MEMORY_ACCESS.get$RawType$Opaque(bb.scope(),
+                bb.unsafeGetBase(), offset(skipAlignmentMaskCheck, bb, base, alignmentMask)));
+    }
+
     @ForceInline
     static void setOpaque(VarHandle ob, Object obb, long base, $type$ value) {
         MemoryAccessVarHandleBase handle = (MemoryAccessVarHandleBase)ob;
@@ -239,6 +324,15 @@ final class MemoryAccessVarHandle$Type$Helper extends MemoryAccessVarHandleBase 
                 bb.unsafeGetBase(),
                 offset(handle.skipAlignmentMaskCheck, bb, base, handle.alignmentMask),
                 convEndian(handle.be, value));
+    }
+
+    // @Override
+    public void setOpaque(Object obb, long base, $type$ value) {
+        MemorySegmentProxy bb = checkAddress(obb, base, length, false);
+        SCOPED_MEMORY_ACCESS.put$RawType$Volatile(bb.scope(),
+                bb.unsafeGetBase(),
+                offset(skipAlignmentMaskCheck, bb, base, alignmentMask),
+                convEndian(be, value));
     }
 #if[CAS]
 
@@ -252,6 +346,15 @@ final class MemoryAccessVarHandle$Type$Helper extends MemoryAccessVarHandleBase 
                 convEndian(handle.be, expected), convEndian(handle.be, value));
     }
 
+    // @Override
+    public boolean compareAndSet(Object obb, long base, $type$ expected, $type$ value) {
+        MemorySegmentProxy bb = checkAddress(obb, base, length, false);
+        return SCOPED_MEMORY_ACCESS.compareAndSet$RawType$(bb.scope(),
+                bb.unsafeGetBase(),
+                offset(skipAlignmentMaskCheck, bb, base, alignmentMask),
+                convEndian(be, expected), convEndian(be, value));
+    }
+
     @ForceInline
     static $type$ compareAndExchange(VarHandle ob, Object obb, long base, $type$ expected, $type$ value) {
         MemoryAccessVarHandleBase handle = (MemoryAccessVarHandleBase)ob;
@@ -261,6 +364,15 @@ final class MemoryAccessVarHandle$Type$Helper extends MemoryAccessVarHandleBase 
                                   bb.unsafeGetBase(),
                                   offset(handle.skipAlignmentMaskCheck, bb, base, handle.alignmentMask),
                                   convEndian(handle.be, expected), convEndian(handle.be, value)));
+    }
+
+    // @Override
+    public $type$ compareAndExchange(Object obb, long base, $type$ expected, $type$ value) {
+        MemorySegmentProxy bb = checkAddress(obb, base, length, false);
+        return convEndian(be, SCOPED_MEMORY_ACCESS.compareAndExchange$RawType$(bb.scope(),
+                bb.unsafeGetBase(),
+                offset(skipAlignmentMaskCheck, bb, base, alignmentMask),
+                convEndian(be, expected), convEndian(be, value)));
     }
 
     @ForceInline
@@ -274,6 +386,15 @@ final class MemoryAccessVarHandle$Type$Helper extends MemoryAccessVarHandleBase 
                                   convEndian(handle.be, expected), convEndian(handle.be, value)));
     }
 
+    // @Override
+    public $type$ compareAndExchangeAcquire(Object obb, long base, $type$ expected, $type$ value) {
+        MemorySegmentProxy bb = checkAddress(obb, base, length, false);
+        return convEndian(be, SCOPED_MEMORY_ACCESS.compareAndExchange$RawType$Acquire(bb.scope(),
+                bb.unsafeGetBase(),
+                offset(skipAlignmentMaskCheck, bb, base, alignmentMask),
+                convEndian(be, expected), convEndian(be, value)));
+    }
+
     @ForceInline
     static $type$ compareAndExchangeRelease(VarHandle ob, Object obb, long base, $type$ expected, $type$ value) {
         MemoryAccessVarHandleBase handle = (MemoryAccessVarHandleBase)ob;
@@ -283,6 +404,15 @@ final class MemoryAccessVarHandle$Type$Helper extends MemoryAccessVarHandleBase 
                                   bb.unsafeGetBase(),
                                   offset(handle.skipAlignmentMaskCheck, bb, base, handle.alignmentMask),
                                   convEndian(handle.be, expected), convEndian(handle.be, value)));
+    }
+
+    // @Override
+    public $type$ compareAndExchangeRelease(Object obb, long base, $type$ expected, $type$ value) {
+        MemorySegmentProxy bb = checkAddress(obb, base, length, false);
+        return convEndian(be, SCOPED_MEMORY_ACCESS.compareAndExchange$RawType$Release(bb.scope(),
+                bb.unsafeGetBase(),
+                offset(skipAlignmentMaskCheck, bb, base, alignmentMask),
+                convEndian(be, expected), convEndian(be, value)));
     }
 
     @ForceInline
@@ -295,6 +425,15 @@ final class MemoryAccessVarHandle$Type$Helper extends MemoryAccessVarHandleBase 
                 convEndian(handle.be, expected), convEndian(handle.be, value));
     }
 
+    // @Override
+    public boolean weakCompareAndSetPlain(Object obb, long base, $type$ expected, $type$ value) {
+        MemorySegmentProxy bb = checkAddress(obb, base, length, false);
+        return SCOPED_MEMORY_ACCESS.weakCompareAndSet$RawType$Plain(bb.scope(),
+                bb.unsafeGetBase(),
+                offset(skipAlignmentMaskCheck, bb, base, alignmentMask),
+                convEndian(be, expected), convEndian(be, value));
+    }
+
     @ForceInline
     static boolean weakCompareAndSet(VarHandle ob, Object obb, long base, $type$ expected, $type$ value) {
         MemoryAccessVarHandleBase handle = (MemoryAccessVarHandleBase)ob;
@@ -303,6 +442,15 @@ final class MemoryAccessVarHandle$Type$Helper extends MemoryAccessVarHandleBase 
                 bb.unsafeGetBase(),
                 offset(handle.skipAlignmentMaskCheck, bb, base, handle.alignmentMask),
                 convEndian(handle.be, expected), convEndian(handle.be, value));
+    }
+
+    // @Override
+    public boolean weakCompareAndSet(Object obb, long base, $type$ expected, $type$ value) {
+        MemorySegmentProxy bb = checkAddress(obb, base, length, false);
+        return SCOPED_MEMORY_ACCESS.weakCompareAndSet$RawType$(bb.scope(),
+                bb.unsafeGetBase(),
+                offset(skipAlignmentMaskCheck, bb, base, alignmentMask),
+                convEndian(be, expected), convEndian(be, value));
     }
 
     @ForceInline
@@ -315,6 +463,15 @@ final class MemoryAccessVarHandle$Type$Helper extends MemoryAccessVarHandleBase 
                 convEndian(handle.be, expected), convEndian(handle.be, value));
     }
 
+    // @Override
+    public boolean weakCompareAndSetAcquire(Object obb, long base, $type$ expected, $type$ value) {
+        MemorySegmentProxy bb = checkAddress(obb, base, length, false);
+        return SCOPED_MEMORY_ACCESS.weakCompareAndSet$RawType$Acquire(bb.scope(),
+                bb.unsafeGetBase(),
+                offset(skipAlignmentMaskCheck, bb, base, alignmentMask),
+                convEndian(be, expected), convEndian(be, value));
+    }
+
     @ForceInline
     static boolean weakCompareAndSetRelease(VarHandle ob, Object obb, long base, $type$ expected, $type$ value) {
         MemoryAccessVarHandleBase handle = (MemoryAccessVarHandleBase)ob;
@@ -323,6 +480,15 @@ final class MemoryAccessVarHandle$Type$Helper extends MemoryAccessVarHandleBase 
                 bb.unsafeGetBase(),
                 offset(handle.skipAlignmentMaskCheck, bb, base, handle.alignmentMask),
                 convEndian(handle.be, expected), convEndian(handle.be, value));
+    }
+
+    // @Override
+    public boolean weakCompareAndSetRelease(Object obb, long base, $type$ expected, $type$ value) {
+        MemorySegmentProxy bb = checkAddress(obb, base, length, false);
+        return SCOPED_MEMORY_ACCESS.weakCompareAndSet$RawType$Release(bb.scope(),
+                bb.unsafeGetBase(),
+                offset(skipAlignmentMaskCheck, bb, base, alignmentMask),
+                convEndian(be, expected), convEndian(be, value));
     }
 
     @ForceInline
@@ -336,6 +502,15 @@ final class MemoryAccessVarHandle$Type$Helper extends MemoryAccessVarHandleBase 
                                   convEndian(handle.be, value)));
     }
 
+    // @Override
+    public $type$ getAndSet(Object obb, long base, $type$ value) {
+        MemorySegmentProxy bb = checkAddress(obb, base, length, false);
+        return convEndian(be, SCOPED_MEMORY_ACCESS.getAndSet$RawType$(bb.scope(),
+                bb.unsafeGetBase(),
+                offset(skipAlignmentMaskCheck, bb, base, alignmentMask),
+                convEndian(be, value)));
+    }
+
     @ForceInline
     static $type$ getAndSetAcquire(VarHandle ob, Object obb, long base, $type$ value) {
         MemoryAccessVarHandleBase handle = (MemoryAccessVarHandleBase)ob;
@@ -347,6 +522,15 @@ final class MemoryAccessVarHandle$Type$Helper extends MemoryAccessVarHandleBase 
                                   convEndian(handle.be, value)));
     }
 
+    // @Override
+    public $type$ getAndSetAcquire(Object obb, long base, $type$ value) {
+        MemorySegmentProxy bb = checkAddress(obb, base, length, false);
+        return convEndian(be, SCOPED_MEMORY_ACCESS.getAndSet$RawType$Acquire(bb.scope(),
+                bb.unsafeGetBase(),
+                offset(skipAlignmentMaskCheck, bb, base, alignmentMask),
+                convEndian(be, value)));
+    }
+
     @ForceInline
     static $type$ getAndSetRelease(VarHandle ob, Object obb, long base, $type$ value) {
         MemoryAccessVarHandleBase handle = (MemoryAccessVarHandleBase)ob;
@@ -356,6 +540,15 @@ final class MemoryAccessVarHandle$Type$Helper extends MemoryAccessVarHandleBase 
                                   bb.unsafeGetBase(),
                                   offset(handle.skipAlignmentMaskCheck, bb, base, handle.alignmentMask),
                                   convEndian(handle.be, value)));
+    }
+
+    // @Override
+    public $type$ getAndSetRelease(Object obb, long base, $type$ value) {
+        MemorySegmentProxy bb = checkAddress(obb, base, length, false);
+        return convEndian(be, SCOPED_MEMORY_ACCESS.getAndSet$RawType$Release(bb.scope(),
+                bb.unsafeGetBase(),
+                offset(skipAlignmentMaskCheck, bb, base, alignmentMask),
+                convEndian(be, value)));
     }
 #end[CAS]
 #if[AtomicAdd]
@@ -374,6 +567,19 @@ final class MemoryAccessVarHandle$Type$Helper extends MemoryAccessVarHandleBase 
         }
     }
 
+    // @Override
+    public $type$ getAndAdd(Object obb, long base, $type$ delta) {
+        MemorySegmentProxy bb = checkAddress(obb, base, length, false);
+        if (be == BE) {
+            return SCOPED_MEMORY_ACCESS.getAndAdd$RawType$(bb.scope(),
+                    bb.unsafeGetBase(),
+                    offset(skipAlignmentMaskCheck, bb, base, alignmentMask),
+                    delta);
+        } else {
+            return getAndAddConvEndianWithCAS(bb, offset(skipAlignmentMaskCheck, bb, base, alignmentMask), delta);
+        }
+    }
+
     @ForceInline
     static $type$ getAndAddAcquire(VarHandle ob, Object obb, long base, $type$ delta) {
         MemoryAccessVarHandleBase handle = (MemoryAccessVarHandleBase)ob;
@@ -388,6 +594,19 @@ final class MemoryAccessVarHandle$Type$Helper extends MemoryAccessVarHandleBase 
         }
     }
 
+    // @Override
+    public $type$ getAndAddAcquire(Object obb, long base, $type$ delta) {
+        MemorySegmentProxy bb = checkAddress(obb, base, length, false);
+        if (be == BE) {
+            return SCOPED_MEMORY_ACCESS.getAndAdd$RawType$Acquire(bb.scope(),
+                    bb.unsafeGetBase(),
+                    offset(skipAlignmentMaskCheck, bb, base, alignmentMask),
+                    delta);
+        } else {
+            return getAndAddConvEndianWithCAS(bb, offset(skipAlignmentMaskCheck, bb, base, alignmentMask), delta);
+        }
+    }
+
     @ForceInline
     static $type$ getAndAddRelease(VarHandle ob, Object obb, long base, $type$ delta) {
         MemoryAccessVarHandleBase handle = (MemoryAccessVarHandleBase)ob;
@@ -399,6 +618,19 @@ final class MemoryAccessVarHandle$Type$Helper extends MemoryAccessVarHandleBase 
                     delta);
         } else {
             return getAndAddConvEndianWithCAS(bb, offset(handle.skipAlignmentMaskCheck, bb, base, handle.alignmentMask), delta);
+        }
+    }
+
+    // @Override
+    public $type$ getAndAddRelease(Object obb, long base, $type$ delta) {
+        MemorySegmentProxy bb = checkAddress(obb, base, length, false);
+        if (be == BE) {
+            return SCOPED_MEMORY_ACCESS.getAndAdd$RawType$Release(bb.scope(),
+                    bb.unsafeGetBase(),
+                    offset(skipAlignmentMaskCheck, bb, base, alignmentMask),
+                    delta);
+        } else {
+            return getAndAddConvEndianWithCAS(bb, offset(skipAlignmentMaskCheck, bb, base, alignmentMask), delta);
         }
     }
 
@@ -430,6 +662,19 @@ final class MemoryAccessVarHandle$Type$Helper extends MemoryAccessVarHandleBase 
         }
     }
 
+    // @Override
+    public $type$ getAndBitwiseOr(Object obb, long base, $type$ value) {
+        MemorySegmentProxy bb = checkAddress(obb, base, length, false);
+        if (be == BE) {
+            return SCOPED_MEMORY_ACCESS.getAndBitwiseOr$RawType$(bb.scope(),
+                    bb.unsafeGetBase(),
+                    offset(skipAlignmentMaskCheck, bb, base, alignmentMask),
+                    value);
+        } else {
+            return getAndBitwiseOrConvEndianWithCAS(bb, offset(skipAlignmentMaskCheck, bb, base, alignmentMask), value);
+        }
+    }
+
     @ForceInline
     static $type$ getAndBitwiseOrRelease(VarHandle ob, Object obb, long base, $type$ value) {
         MemoryAccessVarHandleBase handle = (MemoryAccessVarHandleBase)ob;
@@ -444,6 +689,19 @@ final class MemoryAccessVarHandle$Type$Helper extends MemoryAccessVarHandleBase 
         }
     }
 
+    // @Override
+    public $type$ getAndBitwiseOrRelease(Object obb, long base, $type$ value) {
+        MemorySegmentProxy bb = checkAddress(obb, base, length, false);
+        if (be == BE) {
+            return SCOPED_MEMORY_ACCESS.getAndBitwiseOr$RawType$(bb.scope(),
+                    bb.unsafeGetBase(),
+                    offset(skipAlignmentMaskCheck, bb, base, alignmentMask),
+                    value);
+        } else {
+            return getAndBitwiseOrConvEndianWithCAS(bb, offset(skipAlignmentMaskCheck, bb, base, alignmentMask), value);
+        }
+    }
+
     @ForceInline
     static $type$ getAndBitwiseOrAcquire(VarHandle ob, Object obb, long base, $type$ value) {
         MemoryAccessVarHandleBase handle = (MemoryAccessVarHandleBase)ob;
@@ -455,6 +713,19 @@ final class MemoryAccessVarHandle$Type$Helper extends MemoryAccessVarHandleBase 
                     value);
         } else {
             return getAndBitwiseOrConvEndianWithCAS(bb, offset(handle.skipAlignmentMaskCheck, bb, base, handle.alignmentMask), value);
+        }
+    }
+
+    // @Override
+    public $type$ getAndBitwiseOrAcquire(Object obb, long base, $type$ value) {
+        MemorySegmentProxy bb = checkAddress(obb, base, length, false);
+        if (be == BE) {
+            return SCOPED_MEMORY_ACCESS.getAndBitwiseOr$RawType$(bb.scope(),
+                    bb.unsafeGetBase(),
+                    offset(skipAlignmentMaskCheck, bb, base, alignmentMask),
+                    value);
+        } else {
+            return getAndBitwiseOrConvEndianWithCAS(bb, offset(skipAlignmentMaskCheck, bb, base, alignmentMask), value);
         }
     }
 
@@ -484,6 +755,19 @@ final class MemoryAccessVarHandle$Type$Helper extends MemoryAccessVarHandleBase 
         }
     }
 
+    // @Override
+    public $type$ getAndBitwiseAnd(Object obb, long base, $type$ value) {
+        MemorySegmentProxy bb = checkAddress(obb, base, length, false);
+        if (be == BE) {
+            return SCOPED_MEMORY_ACCESS.getAndBitwiseAnd$RawType$(bb.scope(),
+                    bb.unsafeGetBase(),
+                    offset(skipAlignmentMaskCheck, bb, base, alignmentMask),
+                    value);
+        } else {
+            return getAndBitwiseAndConvEndianWithCAS(bb, offset(skipAlignmentMaskCheck, bb, base, alignmentMask), value);
+        }
+    }
+
     @ForceInline
     static $type$ getAndBitwiseAndRelease(VarHandle ob, Object obb, long base, $type$ value) {
         MemoryAccessVarHandleBase handle = (MemoryAccessVarHandleBase)ob;
@@ -495,6 +779,19 @@ final class MemoryAccessVarHandle$Type$Helper extends MemoryAccessVarHandleBase 
                     value);
         } else {
             return getAndBitwiseAndConvEndianWithCAS(bb, offset(handle.skipAlignmentMaskCheck, bb, base, handle.alignmentMask), value);
+        }
+    }
+
+    // @Override
+    public $type$ getAndBitwiseAndRelease(Object obb, long base, $type$ value) {
+        MemorySegmentProxy bb = checkAddress(obb, base, length, false);
+        if (be == BE) {
+            return SCOPED_MEMORY_ACCESS.getAndBitwiseAnd$RawType$Release(bb.scope(),
+                    bb.unsafeGetBase(),
+                    offset(skipAlignmentMaskCheck, bb, base, alignmentMask),
+                    value);
+        } else {
+            return getAndBitwiseAndConvEndianWithCAS(bb, offset(skipAlignmentMaskCheck, bb, base, alignmentMask), value);
         }
     }
 
@@ -512,6 +809,19 @@ final class MemoryAccessVarHandle$Type$Helper extends MemoryAccessVarHandleBase 
         }
     }
 
+    // @Override
+    public $type$ getAndBitwiseAndAcquire(Object obb, long base, $type$ value) {
+        MemorySegmentProxy bb = checkAddress(obb, base, length, false);
+        if (be == BE) {
+            return SCOPED_MEMORY_ACCESS.getAndBitwiseAnd$RawType$Acquire(bb.scope(),
+                    bb.unsafeGetBase(),
+                    offset(skipAlignmentMaskCheck, bb, base, alignmentMask),
+                    value);
+        } else {
+            return getAndBitwiseAndConvEndianWithCAS(bb, offset(skipAlignmentMaskCheck, bb, base, alignmentMask), value);
+        }
+    }
+
     @ForceInline
     static $type$ getAndBitwiseAndConvEndianWithCAS(MemorySegmentProxy bb, long offset, $type$ value) {
         $type$ nativeExpectedValue, expectedValue;
@@ -524,7 +834,6 @@ final class MemoryAccessVarHandle$Type$Helper extends MemoryAccessVarHandleBase 
         return expectedValue;
     }
 
-
     @ForceInline
     static $type$ getAndBitwiseXor(VarHandle ob, Object obb, long base, $type$ value) {
         MemoryAccessVarHandleBase handle = (MemoryAccessVarHandleBase)ob;
@@ -536,6 +845,19 @@ final class MemoryAccessVarHandle$Type$Helper extends MemoryAccessVarHandleBase 
                     value);
         } else {
             return getAndBitwiseXorConvEndianWithCAS(bb, offset(handle.skipAlignmentMaskCheck, bb, base, handle.alignmentMask), value);
+        }
+    }
+
+    // @Override
+    public $type$ getAndBitwiseXor(Object obb, long base, $type$ value) {
+        MemorySegmentProxy bb = checkAddress(obb, base, length, false);
+        if (be == BE) {
+            return SCOPED_MEMORY_ACCESS.getAndBitwiseXor$RawType$(bb.scope(),
+                    bb.unsafeGetBase(),
+                    offset(skipAlignmentMaskCheck, bb, base, alignmentMask),
+                    value);
+        } else {
+            return getAndBitwiseXorConvEndianWithCAS(bb, offset(skipAlignmentMaskCheck, bb, base, alignmentMask), value);
         }
     }
 
@@ -553,6 +875,19 @@ final class MemoryAccessVarHandle$Type$Helper extends MemoryAccessVarHandleBase 
         }
     }
 
+    // @Override
+    public $type$ getAndBitwiseXorRelease(Object obb, long base, $type$ value) {
+        MemorySegmentProxy bb = checkAddress(obb, base, length, false);
+        if (be == BE) {
+            return SCOPED_MEMORY_ACCESS.getAndBitwiseXor$RawType$Release(bb.scope(),
+                    bb.unsafeGetBase(),
+                    offset(skipAlignmentMaskCheck, bb, base, alignmentMask),
+                    value);
+        } else {
+            return getAndBitwiseXorConvEndianWithCAS(bb, offset(skipAlignmentMaskCheck, bb, base, alignmentMask), value);
+        }
+    }
+
     @ForceInline
     static $type$ getAndBitwiseXorAcquire(VarHandle ob, Object obb, long base, $type$ value) {
         MemoryAccessVarHandleBase handle = (MemoryAccessVarHandleBase)ob;
@@ -564,6 +899,19 @@ final class MemoryAccessVarHandle$Type$Helper extends MemoryAccessVarHandleBase 
                     value);
         } else {
             return getAndBitwiseXorConvEndianWithCAS(bb, offset(handle.skipAlignmentMaskCheck, bb, base, handle.alignmentMask), value);
+        }
+    }
+
+    // @Override
+    public $type$ getAndBitwiseXorAcquire(Object obb, long base, $type$ value) {
+        MemorySegmentProxy bb = checkAddress(obb, base, length, false);
+        if (be == BE) {
+            return SCOPED_MEMORY_ACCESS.getAndBitwiseXor$RawType$Acquire(bb.scope(),
+                    bb.unsafeGetBase(),
+                    offset(skipAlignmentMaskCheck, bb, base, alignmentMask),
+                    value);
+        } else {
+            return getAndBitwiseXorConvEndianWithCAS(bb, offset(skipAlignmentMaskCheck, bb, base, alignmentMask), value);
         }
     }
 


### PR DESCRIPTION
Each `VarHandle` implementation will implement a virtual method variant of the signature-polymorphic base method. This works hand in hand with a change on the Qbicc side which makes sure that the `VarHandle` callers use method signatures which ultimately resolve to these base method overrides.