### PR TITLE
implement Reflection.getCallerClass using StackWalker

### DIFF
--- a/java.base/src/main/java/jdk/internal/reflect/Reflection$_native.java
+++ b/java.base/src/main/java/jdk/internal/reflect/Reflection$_native.java
@@ -32,13 +32,23 @@
 
 package jdk.internal.reflect;
 
+import org.qbicc.runtime.stackwalk.JavaStackWalker;
+import org.qbicc.runtime.stackwalk.StackWalker;
 import org.qbicc.rt.annotation.Tracking;
 
 @Tracking("src/java.base/share/classes/jdk/internal/reflect/Reflection.java")
 public class Reflection$_native {
     public static Class getCallerClass() {
-        // TODO: Real runtime implementation...via libunwind???
-        throw new UnsupportedOperationException();
+        StackWalker sw = new StackWalker();
+        JavaStackWalker javaStackWalker = new JavaStackWalker(true);
+        boolean ok = javaStackWalker.next(sw); // Start
+        ok = ok && javaStackWalker.next(sw);   // Skip me.
+        ok = ok && javaStackWalker.next(sw);   // Skip my caller.
+        if (ok) {
+            return javaStackWalker.getFrameClass();
+        } else {
+            throw new InternalError("Malformed Stack");
+        }
     }
 
     public static int getClassAccessFlags(Class<?> c) {


### PR DESCRIPTION
in conjunction with #196 this allows the 1 argument form of Class.forName to work.

Put in a separate PR because this one shouldn't need to wait for the next qbicc release.
