### PR TITLE
better error reporting from System.initPhase2

### DIFF
--- a/java.base/src/main/java/java/lang/System$_patch.java
+++ b/java.base/src/main/java/java/lang/System$_patch.java
@@ -195,13 +195,10 @@ public final class System$_patch {
 
     @Replace
     private static int initPhase2(boolean printToStderr, boolean printStackTrace) {
-        try {
-            bootLayer = ModuleBootstrap.boot();
-        } catch (Exception | Error e) {
-            logInitException(printToStderr, printStackTrace,
-                    "Error occurred during initialization of boot layer", e);
-            return -1; // JNI_ERR
-        }
+        // For qbicc, we get better error reporting if we simply allow any exception
+        // raised by ModuleBootstrap.boot() to propagate back to VmImpl.initialize()
+        // and be caught and reported there.
+        bootLayer = ModuleBootstrap.boot();
 
         // module system initialized
         VM.initLevel(2);


### PR DESCRIPTION
Drop the JDK code that catches and prints any exception raised by
ModuleBootstrap.boot and just allow error to propagate back to the
interpreter.  This allows us to report the real error, instead of
reporting an error caused by trying to use native IO operations to
write an error message to an interpreted System.out.