### PR TITLE
Remove jrt URL handler from init path

### DIFF
--- a/java.base/src/main/java/java/net/URL$DefaultFactory$_patch.java
+++ b/java.base/src/main/java/java/net/URL$DefaultFactory$_patch.java
@@ -1,0 +1,35 @@
+package java.net;
+
+import org.qbicc.rt.annotation.Tracking;
+import org.qbicc.runtime.patcher.Patch;
+import org.qbicc.runtime.patcher.Replace;
+
+/**
+ *
+ */
+@Patch("java.net.URL$DefaultFactory")
+@Tracking("java.base/classes/share/java/net/URL.java")
+class URL$DefaultFactory$_patch {
+    // alias
+    private static String PREFIX;
+
+    @Replace
+    public URLStreamHandler createURLStreamHandler(String protocol) {
+        // Avoid using reflection during bootstrap
+        switch (protocol) {
+            case "file":
+                return new sun.net.www.protocol.file.Handler();
+            case "jar":
+                return new sun.net.www.protocol.jar.Handler();
+        }
+        String name = PREFIX + protocol + ".Handler";
+        try {
+            Object o = Class.forName(name).getDeclaredConstructor().newInstance();
+            return (URLStreamHandler)o;
+        } catch (Exception e) {
+            // For compatibility, all Exceptions are ignored.
+            // any number of exceptions can get thrown here
+        }
+        return null;
+    }
+}

--- a/java.base/src/main/resources/META-INF/qbicc/qbicc-patch-info
+++ b/java.base/src/main/resources/META-INF/qbicc/qbicc-patch-info
@@ -12,6 +12,7 @@ java.lang.ref.Reference$_patch
 java.lang.ref.Finalizer$_patch
 java.io.FileDescriptor$_runtime
 java.io.FileDescriptor$_patch
+java.net.URL$DefaultFactory$_patch
 java.util.concurrent.atomic.Striped64$_runtime
 java.util.concurrent.ConcurrentHashMap$_runtime
 java.util.concurrent.Exchanger$_patch


### PR DESCRIPTION
This at least temporarily solves the issue of trying to load boot modules into an image. In general I think we do not want to support the `jimage` format anyway, since we're delivering the JDK as JARs.

I am thinking that bootstrapping the modules should be possible without this.