### PR TITLE
Allow `java.logging` to compile without a module for compile annotations

### DIFF
--- a/java.logging/pom.xml
+++ b/java.logging/pom.xml
@@ -102,6 +102,8 @@
                                 <arg>--system</arg>
                                 <arg>none</arg>
                                 <arg>-XDstringConcat=inline</arg>
+                                <arg>--add-reads</arg>
+                                <arg>java.logging=ALL-UNNAMED</arg>
                             </compilerArgs>
                         </configuration>
                     </execution>
@@ -133,7 +135,7 @@
                                     <sourcepath>${project.build.directory}/combined-sources</sourcepath>
                                     <additionalOptions>
                                         <additionalOption>--add-reads</additionalOption>
-                                        <additionalOption>java.base=ALL-UNNAMED</additionalOption>
+                                        <additionalOption>java.logging=ALL-UNNAMED</additionalOption>
                                     </additionalOptions>
                                     <failOnError>false</failOnError>
                                     <failOnWarnings>false</failOnWarnings>

--- a/java.logging/src/main/java/module-info.java
+++ b/java.logging/src/main/java/module-info.java
@@ -37,8 +37,6 @@
  * @since 9
  */
 module java.logging {
-    requires qbicc.rt.annotation;
-
     exports java.util.logging;
 
     provides jdk.internal.logger.DefaultLoggerFinder with


### PR DESCRIPTION
Also fixes a problem where modules cannot be loaded at run time