### PR TITLE
Invoke Heap.initHeap() explicitly, avoid constructor

### DIFF
--- a/java.base/src/main/java/jdk/internal/org/qbicc/runtime/Main.java
+++ b/java.base/src/main/java/jdk/internal/org/qbicc/runtime/Main.java
@@ -53,6 +53,8 @@ public final class Main {
     @export
     @Hidden
     public static c_int main(c_int argc, char_ptr[] argv) {
+        Heap.initHeap(argc.intValue(), addr_of(argv[0]).cast());
+
         // first set up VM
         if (! Heap.checkInit(true)) {
             exit(word(1));


### PR DESCRIPTION
this requires to remove the `@constructor` annotation from `Heap#initHeap` in [qbicc/qbicc](https://github.com/qbicc/qbicc)