### PR TITLE
patch java.lang.Class.ReflectionData

### DIFF
--- a/java.base/src/main/java/java/lang/Class$ReflectionData$_patch.java
+++ b/java.base/src/main/java/java/lang/Class$ReflectionData$_patch.java
@@ -1,0 +1,54 @@
+/*
+ * This code is based on OpenJDK source file(s) which contain the following copyright notice:
+ *
+ * ------
+ * Copyright (c) 2001, 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ * ------
+ *
+ * This file may contain additional modifications which are Copyright (c) Red Hat and other
+ * contributors.
+ */
+package java.lang;
+
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+
+import org.qbicc.rt.annotation.Tracking;
+import org.qbicc.runtime.Build;
+import org.qbicc.runtime.NoReflect;
+import org.qbicc.runtime.patcher.Add;
+import org.qbicc.runtime.patcher.Annotate;
+import org.qbicc.runtime.patcher.Patch;
+import org.qbicc.runtime.patcher.Remove;
+import org.qbicc.runtime.patcher.Replace;
+
+@Patch("java.lang.Class$ReflectionData")
+@Tracking("src/java.base/share/classes/java/lang/Class.java")
+class Class$ReflectionData$_patch<T> {
+
+    @Add
+    Class$ReflectionData$_patch() {
+    }
+}

--- a/java.base/src/main/java/java/lang/Class$_patch.java
+++ b/java.base/src/main/java/java/lang/Class$_patch.java
@@ -1,3 +1,34 @@
+/*
+ * This code is based on OpenJDK source file(s) which contain the following copyright notice:
+ *
+ * ------
+ * Copyright (c) 2001, 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ * ------
+ *
+ * This file may contain additional modifications which are Copyright (c) Red Hat and other
+ * contributors.
+ */
 package java.lang;
 
 import static org.qbicc.runtime.CNative.*;
@@ -43,6 +74,13 @@ final class Class$_patch<T> {
     @Annotate
     @NoReflect
     final ClassLoader classLoader;
+
+    /**
+     * ReflectionData for subset of members that have been annotated as available for runtime reflection
+     */
+    @Add
+    @NoReflect
+    private final transient Class$ReflectionData$_patch<T> qbiccReflectionData;
 
     /**
      * The type ID of (leaf) instances of this class.
@@ -154,6 +192,7 @@ final class Class$_patch<T> {
         this.referenceBitMap = referenceBitMap;
         this.modifiers = modifiers;
         this.dimension = zero();
+        this.qbiccReflectionData = new Class$ReflectionData$_patch<T>();
     }
 
     @Add
@@ -188,6 +227,7 @@ final class Class$_patch<T> {
         this.nestMembers = null;
         this.modifiers = Modifier.PUBLIC | Modifier.ABSTRACT | Modifier.FINAL | refArrayClass.modifiers & 0xffff_0000;
         this.referenceBitMap = refArrayClass.referenceBitMap;
+        this.qbiccReflectionData = new Class$ReflectionData$_patch<T>();
     }
 
     @SuppressWarnings("ConstantConditions")
@@ -230,7 +270,13 @@ final class Class$_patch<T> {
         return nestHost;
     }
 
+    @Replace
+    private Class$ReflectionData$_patch<T> reflectionData() {
+        return qbiccReflectionData;
+    }
+
     // todo: @Replace public Class<?> arrayType() { ... }
     // todo: @Replace public Class<?> componentType() { ... }
     // todo: @Remove private final Class<?> componentType;
+    // todo: @Remove private final SoftReference<ReflectionData<T>> reflectionData
 }

--- a/java.base/src/main/resources/META-INF/qbicc/qbicc-patch-info
+++ b/java.base/src/main/resources/META-INF/qbicc/qbicc-patch-info
@@ -1,5 +1,6 @@
 # Patcher classes. Please keep sorted.
 
+java.lang.Class$ReflectionData$_patch
 java.lang.Class$_patch
 java.lang.Object$_aliases
 java.lang.ProcessEnvironment$_runtime


### PR DESCRIPTION
Some progress towards https://github.com/qbicc/qbicc/issues/1383.  Simplify code to eliminate SoftReference wrapping Class's ReflectionData instance

