### PR TITLE
Add native method VectorSupport.getMaxLaneCount(), which currently re…

### DIFF
--- a/java.base/src/main/java/jdk/internal/vm/vector/VectorSupport$_native.java
+++ b/java.base/src/main/java/jdk/internal/vm/vector/VectorSupport$_native.java
@@ -1,0 +1,43 @@
+/*
+ * This code is based on OpenJDK source file(s) which contain the following copyright notice:
+ *
+ * ------
+ * Copyright (c) 2001, 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ * ------
+ *
+ * This file may contain additional modifications which are Copyright (c) Red Hat and other
+ * contributors.
+ */
+package jdk.internal.vm.vector;
+
+import org.qbicc.rt.annotation.Tracking;
+
+@Tracking("src/java.base/share/classes/jdk/internal/vm/vector/VectorSupport.java")
+public class VectorSupport$_native {
+
+    // query the JVM's supported vector sizes and types
+    public static int getMaxLaneCount(Class<?> etype) {
+        return -1;
+    }
+}


### PR DESCRIPTION
When OpenJDK's C2 is not available, `VectorSupport.getMaxLaneCount` returns -1, which Vector API also expects as commented [here](https://github.com/openjdk/jdk17u/blob/master/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/VectorShape.java#L262). 

We can follow it before the Vector API support.