### PR TITLE
WASM: export `main(argc,argv)` with the expected name

### DIFF
--- a/java.base/src/main/java/jdk/internal/org/qbicc/runtime/Main.java
+++ b/java.base/src/main/java/jdk/internal/org/qbicc/runtime/Main.java
@@ -52,6 +52,7 @@ public final class Main {
 
     @export
     @Hidden
+    @name(value = "__main_argc_argv", when = Build.Target.IsWasi.class)
     public static c_int main(c_int argc, char_ptr[] argv) {
         Heap.initHeap(argc.intValue(), addr_of(argv[0]).cast());
 


### PR DESCRIPTION
- export `main(argc,argv)` with the expected name

EDIT - WIP: I am making sure this change is still needed at all