### PR TITLE
store "native" offset in Field objects

### DIFF
--- a/java.base/src/main/java/java/lang/reflect/Field$_patch.java
+++ b/java.base/src/main/java/java/lang/reflect/Field$_patch.java
@@ -1,0 +1,64 @@
+/*
+ * This code is based on OpenJDK source file(s) which contain the following copyright notice:
+ *
+ * ------
+ * Copyright (c) 2001, 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ * ------
+ *
+ * This file may contain additional modifications which are Copyright (c) Red Hat and other
+ * contributors.
+ */
+
+package java.lang.reflect;
+
+import org.qbicc.rt.annotation.Tracking;
+import org.qbicc.runtime.NoReflect;
+import org.qbicc.runtime.patcher.Add;
+import org.qbicc.runtime.patcher.Annotate;
+import org.qbicc.runtime.patcher.PatchClass;
+
+/**
+ * Build-time patches for {@link Field}.
+ */
+@PatchClass(Field.class)
+@Tracking("src/java.base/share/classes/java/lang/reflect/Field.java")
+public class Field$_patch {
+    // Alias
+    Field root;
+
+    // Stores the offset used by Unsafe.fieldOffset*
+    @Add
+    @NoReflect
+    long offset;
+
+    @Add
+    @NoReflect
+    public long getOffset() {
+        if (root != null) {
+            return ((Field$_patch)(Object)root).getOffset();
+        } else {
+            return offset;
+        }
+    }
+}

--- a/java.base/src/main/java/jdk/internal/misc/Unsafe$_native.java
+++ b/java.base/src/main/java/jdk/internal/misc/Unsafe$_native.java
@@ -38,6 +38,8 @@ import static org.qbicc.runtime.stdc.Stdint.*;
 import static org.qbicc.runtime.stdc.Stdlib.*;
 import static org.qbicc.runtime.stdc.String.*;
 
+import java.lang.reflect.Field;
+import java.lang.reflect.Field$_patch;
 import java.security.ProtectionDomain;
 
 import org.qbicc.rt.annotation.Tracking;
@@ -196,6 +198,14 @@ public final class Unsafe$_native {
                 }
             }
         }
+    }
+
+    private long objectFieldOffset0(Field f) {
+        return ((Field$_patch)(Object)f).getOffset();
+    }
+
+    private long staticFieldOffset0(Field f) {
+        return ((Field$_patch)(Object)f).getOffset();
     }
 
     //TODO:

--- a/java.base/src/main/resources/META-INF/qbicc/qbicc-patch-info
+++ b/java.base/src/main/resources/META-INF/qbicc/qbicc-patch-info
@@ -19,6 +19,7 @@ java.lang.invoke.MethodHandle$_patch
 java.lang.invoke.MethodHandleNatives$CallSiteContext$_patch
 java.lang.ref.Reference$_patch
 java.lang.ref.Finalizer$_patch
+java.lang.reflect.Field$_patch
 java.io.FileDescriptor$_init
 java.io.FileDescriptor$_runtime
 java.io.FileDescriptor$_patch


### PR DESCRIPTION
This is the class lib side of things and needs to be merged first.  After there is a class lib release with the added field, the qbicc change to initialize it when Field objects are instantiated by the interpreter can be dealt with...