### PR TITLE
Implement a few more missing network natives

### DIFF
--- a/java.base/src/main/java/java/net/NetUtil.java
+++ b/java.base/src/main/java/java/net/NetUtil.java
@@ -49,14 +49,14 @@ import org.qbicc.runtime.Build;
 @Tracking("src/java.base/unix/native/libnet/SocketImpl.c")
 @Tracking("src/java.base/windows/native/libnet/net_util_md.c")
 @Tracking("src/java.base/windows/native/libnet/SocketImpl.c")
-public class NetUtil {
+class NetUtil {
     private static boolean IPV4Available;
     private static boolean IPV4AvailableComputed;
 
     private static boolean IPV6Available;
     private static boolean IPV6AvailableComputed;
 
-    public static boolean reuseport_supported() {
+    static boolean reuseport_supported() {
         if (Build.Target.isWindows()) {
             return false;
         } else if (Build.Target.isMacOs() || Build.Target.isLinux()) {
@@ -66,7 +66,7 @@ public class NetUtil {
         }
     }
 
-    public static boolean ipv4_available() {
+    static boolean ipv4_available() {
         if (IPV4AvailableComputed) {
             return IPV4Available;
         }
@@ -87,7 +87,7 @@ public class NetUtil {
         return IPV4Available;
     }
 
-    public static boolean ipv6_available() {
+    static boolean ipv6_available() {
         if (IPV6AvailableComputed) {
             return IPV6Available;
         }
@@ -150,7 +150,7 @@ public class NetUtil {
     }
 
     // NET_GetSockOpt
-    public static c_int getSockOpt(c_int fd, c_int level, c_int opt, void_ptr result, ptr<c_int> len) {
+    static c_int getSockOpt(c_int fd, c_int level, c_int opt, void_ptr result, ptr<c_int> len) {
         socklen_t socklen = auto(len.loadUnshared().cast());
         c_int rv = getsockopt(fd, level, opt, result, addr_of(socklen));
         len.storeUnshared(socklen.cast());
@@ -192,7 +192,7 @@ public class NetUtil {
     }
 
     // NET_SetSockOpt
-    public static c_int setSockOpt(c_int fd, c_int level, c_int  opt, const_void_ptr arg, c_int len) {
+    static c_int setSockOpt(c_int fd, c_int level, c_int  opt, const_void_ptr arg, c_int len) {
         if (level == IPPROTO_IP && opt == IP_TOS) {
             if (Build.Target.isLinux() && ipv6_available()) {
                 throw new UnsupportedOperationException("TODO: finish Linux port of setSockOpt");

--- a/java.base/src/main/java/java/net/NetUtil.java
+++ b/java.base/src/main/java/java/net/NetUtil.java
@@ -33,10 +33,12 @@
 package java.net;
 
 import static org.qbicc.runtime.CNative.*;
+import static org.qbicc.runtime.bsd.SysSysctl.*;
 import static org.qbicc.runtime.posix.ArpaInet.*;
 import static org.qbicc.runtime.posix.NetinetIn.*;
 import static org.qbicc.runtime.posix.SysSocket.*;
 import static org.qbicc.runtime.posix.Unistd.*;
+import static org.qbicc.runtime.stdc.Stddef.*;
 import static org.qbicc.runtime.stdc.Stdint.*;
 
 import org.qbicc.rt.annotation.Tracking;
@@ -145,5 +147,110 @@ public class NetUtil {
         }
 
         return iaObj;
+    }
+
+    // NET_GetSockOpt
+    public static c_int getSockOpt(c_int fd, c_int level, c_int opt, void_ptr result, ptr<c_int> len) {
+        socklen_t socklen = auto(len.loadUnshared().cast());
+        c_int rv = getsockopt(fd, level, opt, result, addr_of(socklen));
+        len.storeUnshared(socklen.cast());
+
+        if (rv.intValue() < 0) {
+            return rv;
+        }
+
+        if (Build.Target.isLinux()) {
+            if ((level == SOL_SOCKET) && ((opt == SO_SNDBUF) || (opt == SO_RCVBUF))) {
+                c_int n = result.loadUnshared(c_int.class);
+                n = word(n.intValue() / 2);
+                result.cast(int_ptr.class).storeUnshared(n);
+            }
+        }
+
+        if (Build.Target.isMacOs()) {
+            if (level == SOL_SOCKET && opt == SO_LINGER) {
+                throw new UnsupportedOperationException("TODO: getting casting to work in getSockOpt");
+                /*
+
+                The C code here is:
+
+                struct linger* to_cast = (struct linger*)result;
+                to_cast->l_linger = (unsigned short)to_cast->l_linger;
+
+                The Java below (and several variants of it) all pass Java compilation but cause
+                an "Invalid field dereference of 'l_linger'" error from qbicc.
+
+                ptr<struct_linger> to_cast = result.cast();
+                c_int tmp = to_cast.sel().l_linger);
+                unsigned_short tmp2 = tmp.cast();
+                to_cast.sel().l_linger = tmp2.cast();
+                 */
+            }
+        }
+
+        return rv;
+    }
+
+    // NET_SetSockOpt
+    public static c_int setSockOpt(c_int fd, c_int level, c_int  opt, const_void_ptr arg, c_int len) {
+        if (level == IPPROTO_IP && opt == IP_TOS) {
+            if (Build.Target.isLinux() && ipv6_available()) {
+                throw new UnsupportedOperationException("TODO: finish Linux port of setSockOpt");
+                // Commented out: missing constants in qbicc runtime headers...
+                /*
+                c_int optval = auto(word(1));
+                if (setsockopt(fd, IPPROTO_IPV6, IPV6FLOW_INFO_SEND, addr_of(optval).cast(), sizeof(optval)).intValue() < 0) {
+                    return -1;
+                }
+                if (setsockopt(fd, IPPROTO_IPV6, IPV6_TCLASS, arg, len).intValue() < 0) {
+                    return -1;
+                }
+
+                 */
+            }
+
+            ptr<c_int> iptos = arg.cast();
+            int iptos_tos_mask = defined(IPTOS_TOS_MASK) ? IPTOS_TOS_MASK.intValue() : 0x1e;
+            int iptos_prec_mask = defined(IPTOS_PREC_MASK) ? IPTOS_PREC_MASK.intValue() : 0xe0;
+            iptos.storeUnshared(word(iptos.loadUnshared().intValue() & (iptos_tos_mask | iptos_prec_mask)));
+        }
+
+        if (Build.Target.isLinux() && level == SOL_SOCKET && opt == SO_RCVBUF) {
+            ptr<c_int> bufsize = arg.cast();
+            if (bufsize.loadUnshared().intValue() < 1024) {
+                bufsize.storeUnshared(word(1024));
+            }
+        }
+
+        if (Build.Target.isMacOs() && level == SOL_SOCKET && (opt == SO_SNDBUF || opt == SO_RCVBUF)) {
+            c_int[] mib = new c_int[] { CTL_KERN, KERN_IPC, KIPC_MAXSOCKBUF };
+            c_int maxsockbuf = auto(word(-1));
+            size_t rlen = auto(sizeof(maxsockbuf));
+            if (sysctl(addr_of(mib[0]), word(3), addr_of(maxsockbuf), addr_of(rlen), word(0), word(0)).intValue() == -1) {
+                maxsockbuf = word(1024);
+            }
+            maxsockbuf = word((maxsockbuf.intValue()/5)*4);
+
+            ptr<c_int> bufsize = arg.cast();
+            if (bufsize.loadUnshared().isGt(maxsockbuf)) {
+                bufsize.storeUnshared(maxsockbuf);
+            }
+            if (opt == SO_RCVBUF && bufsize.loadUnshared().intValue() < 1024) {
+                bufsize.storeUnshared(word(1024));
+            }
+        }
+
+        if (Build.Target.isMacOs() && level == SOL_SOCKET && opt == SO_REUSEADDR) {
+            c_int sotype = auto();
+            socklen_t arglen = auto(sizeof(sotype).cast());
+            if (getsockopt(fd, SOL_SOCKET, SO_TYPE, addr_of(sotype).cast(), addr_of(arglen)).intValue() < 0) {
+                return word(-1);
+            }
+            if (sotype == SOCK_DGRAM) {
+                setsockopt(fd, level, SO_REUSEPORT, arg, len.cast());
+            }
+        }
+
+        return setsockopt(fd, level, opt, arg, len.cast());
     }
 }

--- a/java.base/src/main/java/java/net/NetUtil.java
+++ b/java.base/src/main/java/java/net/NetUtil.java
@@ -47,14 +47,14 @@ import org.qbicc.runtime.Build;
 @Tracking("src/java.base/unix/native/libnet/SocketImpl.c")
 @Tracking("src/java.base/windows/native/libnet/net_util_md.c")
 @Tracking("src/java.base/windows/native/libnet/SocketImpl.c")
-class NetUtil {
+public class NetUtil {
     private static boolean IPV4Available;
     private static boolean IPV4AvailableComputed;
 
     private static boolean IPV6Available;
     private static boolean IPV6AvailableComputed;
 
-    static boolean reuseport_supported() {
+    public static boolean reuseport_supported() {
         if (Build.Target.isWindows()) {
             return false;
         } else if (Build.Target.isMacOs() || Build.Target.isLinux()) {
@@ -64,7 +64,7 @@ class NetUtil {
         }
     }
 
-    static boolean ipv4_available() {
+    public static boolean ipv4_available() {
         if (IPV4AvailableComputed) {
             return IPV4Available;
         }
@@ -85,7 +85,7 @@ class NetUtil {
         return IPV4Available;
     }
 
-    static boolean ipv6_available() {
+    public static boolean ipv6_available() {
         if (IPV6AvailableComputed) {
             return IPV6Available;
         }

--- a/java.base/src/main/java/sun/nio/ch/Net$_native.java
+++ b/java.base/src/main/java/sun/nio/ch/Net$_native.java
@@ -40,7 +40,6 @@ import static org.qbicc.runtime.stdc.Errno.*;
 
 import java.io.FileDescriptor;
 import java.io.IOException;
-import java.net.NetUtil;
 import java.net.SocketException;
 import org.qbicc.rt.annotation.Tracking;
 import org.qbicc.runtime.Build;
@@ -114,11 +113,11 @@ class Net$_native {
     }
 
     private static boolean isIPv6Available0() {
-        return java.net.NetUtil.ipv6_available();
+        return NetUtil$_aliases.ipv6_available();
     }
 
     private static boolean isReusePortAvailable0() {
-        return java.net.NetUtil.reuseport_supported();
+        return NetUtil$_aliases.reuseport_supported();
     }
 
     private static int socket0(boolean preferIPv6, boolean stream, boolean reuse,
@@ -229,7 +228,7 @@ class Net$_native {
         c_int rc;
         c_int cfd = word(((FileDescriptor$_aliases)(Object)fd).fd);
         if (mayNeedConversion) {
-            rc = NetUtil.getSockOpt(cfd, word(level), word(opt), arg, addr_of(arglen).cast());
+            rc = NetUtil$_aliases.getSockOpt(cfd, word(level), word(opt), arg, addr_of(arglen).cast());
         } else {
             rc = getsockopt(cfd, word(level), word(opt), arg, addr_of(arglen));
         }
@@ -281,7 +280,7 @@ class Net$_native {
         c_int rc;
         c_int cfd = word(((FileDescriptor$_aliases)(Object)fd).fd);
         if (mayNeedConversion) {
-            rc = NetUtil.setSockOpt(cfd, level, opt, parg, arglen.cast());
+            rc = NetUtil$_aliases.setSockOpt(cfd, level, opt, parg, arglen.cast());
         } else {
             rc = setsockopt(cfd, level, opt, parg, arglen);
         }

--- a/java.base/src/main/java/sun/nio/ch/Net$_native.java
+++ b/java.base/src/main/java/sun/nio/ch/Net$_native.java
@@ -112,8 +112,11 @@ class Net$_native {
     }
 
     private static boolean isIPv6Available0() {
-        // TODO: Figure this out for real
-        return false;
+        return java.net.NetUtil.ipv6_available();
+    }
+
+    private static boolean isReusePortAvailable0() {
+        return java.net.NetUtil.reuseport_supported();
     }
 
     private static int socket0(boolean preferIPv6, boolean stream, boolean reuse,

--- a/java.base/src/main/java/sun/nio/ch/Net$_native.java
+++ b/java.base/src/main/java/sun/nio/ch/Net$_native.java
@@ -38,7 +38,9 @@ import static org.qbicc.runtime.posix.SysSocket.*;
 import static org.qbicc.runtime.posix.Unistd.*;
 import static org.qbicc.runtime.stdc.Errno.*;
 
+import java.io.FileDescriptor;
 import java.io.IOException;
+import java.net.NetUtil;
 import java.net.SocketException;
 import org.qbicc.rt.annotation.Tracking;
 import org.qbicc.runtime.Build;
@@ -194,6 +196,97 @@ class Net$_native {
             return fd.intValue();
         } else {
             throw new UnsupportedOperationException();
+        }
+    }
+
+    private static int getIntOption0(FileDescriptor fd, boolean mayNeedConversion, int level, int opt) throws IOException {
+        c_int result = auto();
+        struct_linger linger = auto();
+        c_char carg = auto();
+        void_ptr arg = auto(addr_of(result).cast());
+        socklen_t arglen = auto(sizeof(result)).cast();
+
+        if (level == IPPROTO_IP.intValue() &&
+                (opt == IP_MULTICAST_TTL.intValue() || opt == IP_MULTICAST_LOOP.intValue())) {
+            throw new UnsupportedOperationException("TODO: fix casting of carg in getIntOption0");
+
+            /*
+            TODO: This generates invalid LLVM IR from qbicc
+            arg = addr_of(carg).cast();
+            arglen = sizeof(carg).cast();
+            */
+        }
+
+        if (level == SOL_SOCKET.intValue() && opt == SO_LINGER.intValue()) {
+            throw new UnsupportedOperationException("TODO: fix casting of linger in getIntOption0");
+            /*
+            TODO: This generates invalid LLVM IR from qbicc
+            arg = addr_of(linger).cast();
+            arglen = sizeof(linger).cast();
+             */
+        }
+
+        c_int rc;
+        c_int cfd = word(((FileDescriptor$_aliases)(Object)fd).fd);
+        if (mayNeedConversion) {
+            rc = NetUtil.getSockOpt(cfd, word(level), word(opt), arg, addr_of(arglen).cast());
+        } else {
+            rc = getsockopt(cfd, word(level), word(opt), arg, addr_of(arglen));
+        }
+        if (rc.intValue() < 0) {
+            throw new SocketException("sun.nio.ch.Net.getIntOption");
+        }
+
+        if (level == IPPROTO_IP.intValue() &&
+                (opt == IP_MULTICAST_TTL.intValue() || opt == IP_MULTICAST_LOOP.intValue())) {
+            return carg.intValue();
+        }
+
+        if (level == SOL_SOCKET.intValue() && opt == SO_LINGER.intValue()) {
+            return linger.l_onoff.booleanValue() ? linger.l_linger.intValue() : -1;
+        }
+
+        return result.intValue();
+    }
+
+    private static void setIntOption0(FileDescriptor fd, boolean mayNeedConversion, int jlevel, int jopt, int jarg, boolean isIPv6) throws IOException {
+        struct_linger linger = auto();
+        c_char carg = auto();
+        c_int arg = auto(word(jarg));
+        c_int level = word(jlevel);
+        c_int opt = word(jopt);
+
+        /* Option value is an int except for a few specific cases */
+        const_void_ptr parg = addr_of(arg).cast();
+        socklen_t arglen = sizeof(arg).cast();
+
+        if (level == IPPROTO_IP && (opt == IP_MULTICAST_TTL || opt == IP_MULTICAST_LOOP)) {
+            parg = addr_of(carg).cast();
+            arglen = sizeof(carg).cast();
+            carg = arg.cast();
+        }
+
+        if (level == SOL_SOCKET && opt == SO_LINGER) {
+            parg = addr_of(linger).cast();
+            arglen = sizeof(linger).cast();
+            if (jarg >= 0) {
+                linger.l_onoff = word(1);
+                linger.l_linger = arg;
+            } else {
+                linger.l_onoff = word(0);
+                linger.l_linger = word(0);
+            }
+        }
+
+        c_int rc;
+        c_int cfd = word(((FileDescriptor$_aliases)(Object)fd).fd);
+        if (mayNeedConversion) {
+            rc = NetUtil.setSockOpt(cfd, level, opt, parg, arglen.cast());
+        } else {
+            rc = setsockopt(cfd, level, opt, parg, arglen);
+        }
+        if (rc.intValue() < 0) {
+            throw new SocketException("sun.nio.ch.Net.setIntOption");
         }
     }
 }

--- a/java.base/src/main/java/sun/nio/ch/NetUtil$_aliases.java
+++ b/java.base/src/main/java/sun/nio/ch/NetUtil$_aliases.java
@@ -1,0 +1,14 @@
+package sun.nio.ch;
+
+import static org.qbicc.runtime.CNative.*;
+
+import org.qbicc.runtime.patcher.Patch;
+
+@Patch("java.net.NetUtil")
+class NetUtil$_aliases {
+    // alias to make java.net.NetUtil methods accessible in this package
+    static native boolean reuseport_supported();
+    static native boolean ipv6_available();
+    static native c_int getSockOpt(c_int fd, c_int level, c_int opt, void_ptr result, ptr<c_int> len);
+    static native c_int setSockOpt(c_int fd, c_int level, c_int opt, const_void_ptr arg, c_int len);
+}

--- a/java.base/src/main/resources/META-INF/qbicc/qbicc-patch-info
+++ b/java.base/src/main/resources/META-INF/qbicc/qbicc-patch-info
@@ -53,6 +53,7 @@ sun.nio.ch.FileDescriptor$_aliases
 sun.nio.ch.FileDispatcherImpl$_runtime
 sun.nio.ch.IOUtil$_patch
 sun.nio.ch.Net$_patch
+sun.nio.ch.NetUtil$_aliases
 sun.nio.fs.NativeBuffer$_patch
 sun.nio.fs.NativeBuffers$_patch
 sun.nio.fs.UnixFileAttributes$_aliases


### PR DESCRIPTION
This appears to be enough to allow Quarkus to get past attempting to opening a serversocket on MacOS.

Needs a qbicc release that includes https://github.com/qbicc/qbicc/pull/1636

