### PR TITLE
another batch of missing networking natives

### DIFF
--- a/java.base/src/main/java/java/lang/ProcessEnvironment.java
+++ b/java.base/src/main/java/java/lang/ProcessEnvironment.java
@@ -420,22 +420,25 @@ final class ProcessEnvironment {
         ByteArrayOutputStream baos = new ByteArrayOutputStream();
         OutputStreamWriter w = new OutputStreamWriter(baos, StandardCharsets.UTF_8);
         int cnt = 0;
-        for (Map.Entry<String, String> entry : map.entrySet()) try {
-            String key = entry.getKey();
-            String value = entry.getValue();
-            if (! isValidName(key) || ! isValidValue(value)) {
-                // skip the key for safety
-                continue;
-            }
-            cnt++;
-            w.write(key);
-            w.write('\0');
-            w.write(value);
-            w.write('\0');
-            w.flush();
-        } catch (IOException e) {
-            // impossible
-            throw new IllegalStateException();
+        if (map != null) {
+            for (Map.Entry<String, String> entry : map.entrySet())
+                try {
+                    String key = entry.getKey();
+                    String value = entry.getValue();
+                    if (!isValidName(key) || !isValidValue(value)) {
+                        // skip the key for safety
+                        continue;
+                    }
+                    cnt++;
+                    w.write(key);
+                    w.write('\0');
+                    w.write(value);
+                    w.write('\0');
+                    w.flush();
+                } catch (IOException e) {
+                    // impossible
+                    throw new IllegalStateException();
+                }
         }
         envCnt[0] = cnt;
         return baos.toByteArray();

--- a/java.base/src/main/java/java/net/NetUtil.java
+++ b/java.base/src/main/java/java/net/NetUtil.java
@@ -209,22 +209,10 @@ class NetUtil {
 
         if (Build.Target.isMacOs()) {
             if (level == SOL_SOCKET && opt == SO_LINGER) {
-                throw new UnsupportedOperationException("TODO: getting casting to work in getSockOpt");
-                /*
-
-                The C code here is:
-
-                struct linger* to_cast = (struct linger*)result;
-                to_cast->l_linger = (unsigned short)to_cast->l_linger;
-
-                The Java below (and several variants of it) all pass Java compilation but cause
-                an "Invalid field dereference of 'l_linger'" error from qbicc.
-
                 ptr<struct_linger> to_cast = result.cast();
-                c_int tmp = to_cast.sel().l_linger);
+                c_int tmp = to_cast.sel().l_linger;
                 unsigned_short tmp2 = tmp.cast();
                 to_cast.sel().l_linger = tmp2.cast();
-                 */
             }
         }
 

--- a/java.base/src/main/java/sun/nio/ch/Net$_native.java
+++ b/java.base/src/main/java/sun/nio/ch/Net$_native.java
@@ -35,6 +35,7 @@ package sun.nio.ch;
 import static org.qbicc.runtime.CNative.*;
 import static org.qbicc.runtime.posix.Errno.*;
 import static org.qbicc.runtime.posix.NetinetIn.*;
+import static org.qbicc.runtime.posix.Poll.*;
 import static org.qbicc.runtime.posix.SysSocket.*;
 import static org.qbicc.runtime.posix.Unistd.*;
 import static org.qbicc.runtime.stdc.Errno.*;
@@ -413,6 +414,26 @@ class Net$_native {
         }
         if (rc.intValue() < 0) {
             throw new SocketException("sun.nio.ch.Net.setIntOption");
+        }
+    }
+
+    static int poll(FileDescriptor fd, int events, long timeout) throws IOException {
+        struct_pollfd pfd = auto();
+        pfd.fd = word(((FileDescriptor$_aliases) (Object) fd).fd);
+        pfd.events = word(events);
+        if (timeout < -1) {
+            timeout = -1;
+        } else if (timeout > Integer.MAX_VALUE) {
+            timeout = Integer.MAX_VALUE;
+        }
+        c_int rv = Poll.poll(addr_of(pfd), word(1), word(timeout));
+
+        if (rv.intValue() >= 0) {
+            return pfd.revents.intValue();
+        } else if (errno == EINTR.intValue()) {
+            return 0;
+        } else {
+            throw new SocketException();
         }
     }
 }

--- a/java.base/src/main/java/sun/nio/ch/Net$_native.java
+++ b/java.base/src/main/java/sun/nio/ch/Net$_native.java
@@ -274,6 +274,20 @@ class Net$_native {
         return 1;
     }
 
+    static void shutdown(FileDescriptor fd, int how) throws IOException {
+        c_int cfd = word(((FileDescriptor$_aliases)(Object)fd).fd);
+        c_int chow = switch(how) {
+            case Net.SHUT_RD -> SHUT_RD;
+            case Net.SHUT_WR -> SHUT_WR;
+            default -> SHUT_RDWR;
+        };
+        if (SysSocket.shutdown(cfd, chow).intValue() < 0) {
+            if (errno != ENOTCONN.intValue()) {
+                throw new SocketException();
+            }
+        }
+    }
+
     private static int connect0(boolean preferIPv6, FileDescriptor fd, InetAddress remote, int remotePort) throws IOException {
         struct_sockaddr_in6 sa = auto(); // in OpenJDK, this local is a union of sockaddr, sockaddr_in, and sockaddr_in6.  Pick the biggest....
         socklen_t sa_len = auto(sizeof(sa).cast());


### PR DESCRIPTION
This gets the request-response portion of knative-quarkus-bench `server-reply` working