### PR TITLE
Use explicit fields for `header` and `typeId`

### DIFF
--- a/java.base/src/main/java/java/lang/Object.java
+++ b/java.base/src/main/java/java/lang/Object.java
@@ -49,6 +49,12 @@ import org.qbicc.runtime.main.VMHelpers;
 public class Object {
 
     @NoReflect
+    header_type header;
+
+    @NoReflect
+    type_id typeId;
+
+    @NoReflect
     private Monitor monitor;
 
     @NoReflect


### PR DESCRIPTION
This allows us to more easily access these fields for things like GC, lock nursery, etc.