### PR TITLE
simplify getGenericSignature0; stub getParameters0

### DIFF
--- a/java.base/src/main/java/java/lang/Class$_native.java
+++ b/java.base/src/main/java/java/lang/Class$_native.java
@@ -174,10 +174,6 @@ public final class Class$_native<T> {
     }
 
     String getGenericSignature0() {
-        if (Build.isTarget()) {
-            return ((Class$_patch) (Object) this).genericSignature;
-        } else {
-            throw new IllegalStateException("Class.getGenericSignature0() should have been intercepted in the interpreter!");
-        }
+        return ((Class$_patch) (Object) this).genericSignature;
     }
 }

--- a/java.base/src/main/java/java/lang/reflect/Executable$_patch.java
+++ b/java.base/src/main/java/java/lang/reflect/Executable$_patch.java
@@ -1,0 +1,54 @@
+/*
+ * This code is based on OpenJDK source file(s) which contain the following copyright notice:
+ *
+ * ------
+ * Copyright (c) 2001, 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ * ------
+ *
+ * This file may contain additional modifications which are Copyright (c) Red Hat and other
+ * contributors.
+ */
+
+package java.lang.reflect;
+
+import jdk.internal.reflect.MethodAccessor;
+
+import org.qbicc.rt.annotation.Tracking;
+import org.qbicc.runtime.Build;
+import org.qbicc.runtime.patcher.Add;
+import org.qbicc.runtime.patcher.PatchClass;
+import org.qbicc.runtime.patcher.Replace;
+
+/**
+ * Build-time patches for {@link Executable}.
+ */
+@PatchClass(Executable.class)
+@Tracking("src/java.base/share/classes/java/lang/reflect/Executable.java")
+public class Executable$_patch {
+
+    @Replace
+    private Parameter[] getParameters0() {
+        return null;
+    }
+}

--- a/java.base/src/main/resources/META-INF/qbicc/qbicc-patch-info
+++ b/java.base/src/main/resources/META-INF/qbicc/qbicc-patch-info
@@ -21,6 +21,7 @@ java.lang.invoke.MethodHandleNatives$CallSiteContext$_patch
 java.lang.ref.Reference$_patch
 java.lang.ref.Finalizer$_patch
 java.lang.reflect.Constructor$_patch
+java.lang.reflect.Executable$_patch
 java.lang.reflect.Field$_patch
 java.lang.reflect.Method$_patch
 java.lang.reflect.MethodHandleAccessorFactory$_aliases


### PR DESCRIPTION
This will eventually allow us to get rid of the hook.  We initialize `genericSignature` when we initialize the VmClass instance.