### PR TITLE
Avoid generating redundant lambda class name suffix

### DIFF
--- a/java.base/src/main/java/java/lang/invoke/InnerClassLambdaMetafactory$_patch.java
+++ b/java.base/src/main/java/java/lang/invoke/InnerClassLambdaMetafactory$_patch.java
@@ -1,0 +1,22 @@
+package java.lang.invoke;
+
+import org.qbicc.runtime.patcher.PatchClass;
+import org.qbicc.runtime.patcher.Replace;
+
+/**
+ *
+ */
+@PatchClass(InnerClassLambdaMetafactory.class)
+class InnerClassLambdaMetafactory$_patch {
+
+    @Replace
+    private static String lambdaClassName(Class<?> targetClass) {
+        String name = targetClass.getName();
+        if (targetClass.isHidden()) {
+            // use the original class name
+            name = name.replace('/', '_');
+        }
+        // the class is hidden, so we don't need to put a numerical suffix on it
+        return name.replace('.', '/') + "$$Lambda";
+    }
+}

--- a/java.base/src/main/resources/META-INF/qbicc/qbicc-patch-info
+++ b/java.base/src/main/resources/META-INF/qbicc/qbicc-patch-info
@@ -15,6 +15,7 @@ java.lang.System$_init
 java.lang.System$_runtime
 java.lang.Thread$_patch
 java.lang.invoke.DirectMethodHandle$_patch
+java.lang.invoke.InnerClassLambdaMetafactory$_patch
 java.lang.invoke.MemberName$_patch
 java.lang.invoke.MethodHandle$_patch
 java.lang.invoke.MethodHandleNatives$CallSiteContext$_patch


### PR DESCRIPTION
Hidden classes already have a unique suffix; having one on the lambda class too just makes a mess in the build directory.

Once this is merged and qbicc/qbicc#1687 is resolved, repeated builds will no longer pollute the target directory with duplicate files under different names.

Needs a qbicc release because this change exposes the problem that is fixed by qbicc/qbicc#1699.