### PR TITLE
Update to qbicc 0.65.0 with source compatibility changes

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -1,7 +1,7 @@
 name: qbicc-class-libraries Continuous Integration
 env:
   CLASSLIB_VERSION: 17.alpha.0.50-SNAPSHOT
-  QBICC_VERSION: 0.64.0
+  QBICC_VERSION: 0.65.0
 on:
   push:
     paths-ignore:

--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,7 @@
         <sh>/bin/sh</sh>
         <make>/usr/bin/make</make>
         <!-- IMPORTANT: when updating this value, also update .github/workflows/maven.yml -->
-        <version.qbicc>0.64.0</version.qbicc>
+        <version.qbicc>0.65.0</version.qbicc>
 
         <!-- This tracks the version of OpenJDK sources in the git submodule -->
         <version.openjdk>17.0.4.1</version.openjdk>


### PR DESCRIPTION
qbicc 0.65.0 is binary-compatible with 0.64.0 but not source-compatible. Include fixes to ensure that compilation succeeds (using non-deprecated methods).