### PR TITLE
simplify deref expessions

### DIFF
--- a/java.base/src/main/java/java/net/Inet6AddressImpl$_qbicc.java
+++ b/java.base/src/main/java/java/net/Inet6AddressImpl$_qbicc.java
@@ -106,11 +106,11 @@ class Inet6AddressImpl$_qbicc {
              * exclude them in the normal case, but return them if we don't get an IP
              * address.
              */
-            for (struct_ifaddrs_ptr iter = ifa.cast(); !iter.isNull(); iter = addr_of(iter.sel().ifa_next).loadUnshared().cast()) {
-                if (!addr_of(iter.sel().ifa_addr).loadUnshared().isNull()) {
-                    int family = addr_of(addr_of(iter.sel().ifa_addr).loadUnshared().sel().sa_family).loadUnshared().intValue();
+            for (struct_ifaddrs_ptr iter = ifa.cast(); !iter.isNull(); iter = iter.sel().ifa_next.cast()) {
+                if (!iter.sel().ifa_addr.isNull()) {
+                    int family = iter.sel().ifa_addr.sel().sa_family.intValue();
                     if (addr_of(iter.sel().ifa_name).loadUnshared().asArray()[0] != word('\0')) {
-                        boolean isLoopback = (addr_of(iter.sel().ifa_flags).loadUnshared().intValue() & IFF_LOOPBACK.intValue()) != 0;
+                        boolean isLoopback = (iter.sel().ifa_flags.intValue() & IFF_LOOPBACK.intValue()) != 0;
                         if (family == AF_INET.intValue()) {
                             addrs4++;
                             if (isLoopback) numV4Loopbacks++;
@@ -142,16 +142,16 @@ class Inet6AddressImpl$_qbicc {
             }
 
             // Now loop around the ifaddrs
-            for (struct_ifaddrs_ptr iter = ifa.cast(); !iter.isNull(); iter = addr_of(iter.sel().ifa_next).loadUnshared().cast()) {
-                if (!addr_of(iter.sel().ifa_addr).loadUnshared().isNull()) {
-                    int family = addr_of(addr_of(iter.sel().ifa_addr).loadUnshared().sel().sa_family).loadUnshared().intValue();
-                    boolean isLoopback = (addr_of(iter.sel().ifa_flags).loadUnshared().intValue() & IFF_LOOPBACK.intValue()) != 0;
+            for (struct_ifaddrs_ptr iter = ifa.cast(); !iter.isNull(); iter = iter.sel().ifa_next.cast()) {
+                if (!iter.sel().ifa_addr.isNull()) {
+                    int family = iter.sel().ifa_addr.sel().sa_family.intValue();
+                    boolean isLoopback = (iter.sel().ifa_flags.intValue() & IFF_LOOPBACK.intValue()) != 0;
                     if (addr_of(iter.sel().ifa_name).loadUnshared().asArray()[0] != word('\0') &&
                             (family == AF_INET.intValue() || (family == AF_INET6.intValue() && includeV6)) &&
                             (!isLoopback || includeLoopback)) {
                         c_int port = auto();
                         int index = (family == AF_INET.intValue()) ? i++ : j++;
-                        InetAddress o = NetUtil.sockaddrToInetAddress(addr_of(iter.sel().ifa_addr).loadUnshared().cast(), addr_of(port));
+                        InetAddress o = NetUtil.sockaddrToInetAddress(iter.sel().ifa_addr.cast(), addr_of(port));
                         o.holder().hostName = name;
                         result[index] = o;
                     }
@@ -286,7 +286,7 @@ class Inet6AddressImpl$_qbicc {
                     if (iterator.sel().ai_family == AF_INET) {
                         Inet4Address iaObj = new Inet4Address();
                         ptr<struct_sockaddr_in> addr1 = iterator.sel().ai_addr.cast();
-                        iaObj.holder().address = ntohl(addr_of(addr1.sel().sin_addr.s_addr).loadUnshared(uint32_t.class)).intValue();
+                        iaObj.holder().address = ntohl(addr1.sel().sin_addr.s_addr.cast()).intValue();
                         iaObj.holder().hostName = host;
                         iaObj.holder().originalHostName = host;
                         ret[inetIndex | originalIndex] = iaObj;

--- a/java.base/src/main/java/java/net/NetUtil.java
+++ b/java.base/src/main/java/java/net/NetUtil.java
@@ -124,13 +124,13 @@ class NetUtil {
 
     // NET_GetPortFromSockaddr
     static c_int getPortFromSockaddr(/*SOCKETADDRESS* */ void_ptr sa) {
-        c_int family = addr_of(sa.cast(struct_sockaddr_ptr.class).sel().sa_family).loadUnshared().cast();
+        c_int family = sa.cast(struct_sockaddr_ptr.class).sel().sa_family.cast();
         if (family == AF_INET6) {
             struct_sockaddr_in6_ptr sa6 = sa.cast();
-            return ntohs(addr_of(sa6.sel().sin6_port).loadUnshared().cast()).cast();
+            return ntohs(sa6.sel().sin6_port.cast()).cast();
         } else {
             struct_sockaddr_in_ptr sa4 = sa.cast();
-            return ntohs(addr_of(sa4.sel().sin_port).loadUnshared().cast()).cast();
+            return ntohs(sa4.sel().sin_port.cast()).cast();
         }
     }
 
@@ -161,7 +161,7 @@ class NetUtil {
     // NET_SockaddrToInetAddress
     static InetAddress sockaddrToInetAddress(/*SOCKADDRESS* */void_ptr sa, ptr<c_int> port) {
         InetAddress iaObj;
-        c_int family = addr_of(sa.cast(struct_sockaddr_ptr.class).sel().sa_family).loadUnshared().cast();
+        c_int family = sa.cast(struct_sockaddr_ptr.class).sel().sa_family.cast();
         if (family == AF_INET6) {
             struct_sockaddr_in6_ptr sa6 = sa.cast();
             ptr<uint8_t> caddr = addr_of(sa6.sel().sin6_addr.s6_addr[0]);
@@ -174,16 +174,16 @@ class NetUtil {
                 Inet6Address$_patch ia6Obj = (Inet6Address$_patch)(Object)iaObj;
                 iaObj.holder().family = InetAddress.IPv6;
                 ia6Obj.setInet6Address_ipaddress(caddr);
-                ia6Obj.setInet6Address_scopeid(addr_of(sa6.sel().sin6_scope_id).loadUnshared().intValue());
+                ia6Obj.setInet6Address_scopeid(sa6.sel().sin6_scope_id.intValue());
             }
-            port.storeUnshared(ntohs(addr_of(sa6.sel().sin6_port).loadUnshared().cast()).cast());
+            port.storeUnshared(ntohs(sa6.sel().sin6_port.cast()).cast());
         } else {
             struct_sockaddr_in_ptr sa4 = sa.cast();
             iaObj = new Inet4Address();
             iaObj.holder().family = InetAddress.IPv4;
-            unsigned_int addr = ntohl(addr_of(sa4.sel().sin_addr.s_addr).loadUnshared().cast()).cast();
+            unsigned_int addr = ntohl(sa4.sel().sin_addr.s_addr.cast()).cast();
             iaObj.holder().address = addr.intValue();
-            port.storeUnshared(ntohs(addr_of(sa4.sel().sin_port).loadUnshared().cast()).cast());
+            port.storeUnshared(ntohs(sa4.sel().sin_port.cast()).cast());
         }
 
         return iaObj;
@@ -285,10 +285,10 @@ class NetUtil {
     // NET_Bind
     static c_int bind(c_int fd, /*SOCKETADDRESS* */ void_ptr sa, c_int len) {
         if (Build.Target.isLinux()) {
-            c_int family = addr_of(sa.cast(struct_sockaddr_ptr.class).sel().sa_family).loadUnshared().cast();
+            c_int family = sa.cast(struct_sockaddr_ptr.class).sel().sa_family.cast();
             if (family == AF_INET) {
                 struct_sockaddr_in_ptr sa_in = sa.cast(struct_sockaddr_in_ptr.class);
-                if ((ntohl(addr_of(sa_in.sel().sin_addr).loadUnshared(struct_in_addr.class).s_addr.cast()).intValue() & 0x7f0000ff) == 0x7f0000ff) {
+                if ((ntohl(sa_in.sel().sin_addr.s_addr.cast()).intValue() & 0x7f0000ff) == 0x7f0000ff) {
                     errno = EADDRNOTAVAIL.intValue();
                     return word(-1);
                 }

--- a/java.base/src/main/java/java/net/NetworkInterface$_qbicc.java
+++ b/java.base/src/main/java/java/net/NetworkInterface$_qbicc.java
@@ -327,23 +327,22 @@ class NetworkInterface$_qbicc {
             }
 
             try {
-                for (struct_ifaddrs_ptr ifa = origifa; !ifa.isNull(); ifa = addr_of(ifa.sel().ifa_next).loadUnshared().cast()) {
+                for (struct_ifaddrs_ptr ifa = origifa; !ifa.isNull(); ifa = ifa.sel().ifa_next.cast()) {
                     ptr<struct_sockaddr> broadaddrP = word(0);
 
                     // ignore non IPv4 addresses
-                    if (addr_of(ifa.sel().ifa_addr).loadUnshared().isNull() ||
-                            addr_of(addr_of(ifa.sel().ifa_addr).loadUnshared().sel().sa_family).loadUnshared().intValue() != AF_INET.intValue()) {
+                    if (ifa.sel().ifa_addr.isNull() || ifa.sel().ifa_addr.sel().sa_family.intValue() != AF_INET.intValue()) {
                         continue;
                     }
 
                     // set ifa_broadaddr, if there is one
-                    if ((addr_of(ifa.sel().ifa_flags).loadUnshared().intValue() & IFF_POINTOPOINT.intValue()) == 0 &&
-                            (addr_of(ifa.sel().ifa_flags).loadUnshared().intValue() & IFF_BROADCAST.intValue()) != 0) {
-                        broadaddrP = addr_of(ifa.sel().ifa_dstaddr).loadUnshared();
+                    if ((ifa.sel().ifa_flags.intValue() & IFF_POINTOPOINT.intValue()) == 0 &&
+                            (ifa.sel().ifa_flags.intValue() & IFF_BROADCAST.intValue()) != 0) {
+                        broadaddrP = ifa.sel().ifa_dstaddr;
                     }
 
-                    ifs = addif(sock, addr_of(ifa.sel().ifa_name).loadUnshared().cast(), ifs, addr_of(ifa.sel().ifa_addr).loadUnshared(),
-                            broadaddrP, AF_INET, translateIPv4AddressToPrefix(addr_of(ifa.sel().ifa_netmask).loadUnshared().cast()));
+                    ifs = addif(sock, ifa.sel().ifa_name.cast(), ifs, ifa.sel().ifa_addr,
+                            broadaddrP, AF_INET, translateIPv4AddressToPrefix(ifa.sel().ifa_netmask.cast()));
                 }
             } finally {
                 freeifaddrs(origifa);
@@ -415,13 +414,13 @@ class NetworkInterface$_qbicc {
             InetAddress iaObj = null;
             if (addrP.family == AF_INET) {
                 iaObj = new Inet4Address();
-                unsigned_int tmpAddr = htonl(addr_of(addrP.addr.cast(struct_sockaddr_in_ptr.class).sel().sin_addr).loadUnshared(struct_in_addr.class).s_addr.cast()).cast();
+                unsigned_int tmpAddr = htonl(addrP.addr.cast(struct_sockaddr_in_ptr.class).sel().sin_addr.s_addr.cast()).cast();
                 iaObj.holder().address = tmpAddr.intValue();
                 InterfaceAddress ibObj = new InterfaceAddress();
                 ((InterfaceAddress$_patch)(Object)ibObj).address = iaObj;
                 if (!addrP.brdcast.isNull()) {
                     Inet4Address ia2Obj = new Inet4Address();
-                    unsigned_int tmpBAddr = htonl(addr_of(addrP.brdcast.cast(struct_sockaddr_in_ptr.class).sel().sin_addr).loadUnshared(struct_in_addr.class).s_addr.cast()).cast();
+                    unsigned_int tmpBAddr = htonl(addrP.brdcast.cast(struct_sockaddr_in_ptr.class).sel().sin_addr.s_addr.cast()).cast();
                     ia2Obj.holder().address = tmpBAddr.intValue();
                     ((InterfaceAddress$_patch)(Object)ibObj).broadcast = ia2Obj;
                 }
@@ -433,7 +432,7 @@ class NetworkInterface$_qbicc {
                 Inet6Address$_patch ia6Obj = (Inet6Address$_patch)(Object)iaObj;
                 ptr<uint8_t> addr = addr_of(addr_of(addrP.addr.cast(struct_sockaddr_in6_ptr.class).sel().sin6_addr).sel().s6_addr[0]);
                 ia6Obj.setInet6Address_ipaddress(addr);
-                uint32_t scope = addr_of(addrP.addr.cast(struct_sockaddr_in6_ptr.class).sel().sin6_scope_id).loadUnshared(uint32_t.class);
+                uint32_t scope = addrP.addr.cast(struct_sockaddr_in6_ptr.class).sel().sin6_scope_id.cast();
                 if (scope.intValue() != 0) {
                     ia6Obj.setInet6Address_scopeid(scope.intValue());
                     ia6Obj.setInet6Address_scope_ifname((NetworkInterface)(Object)netifObj);

--- a/java.base/src/main/java/sun/nio/fs/UnixNativeDispatcher$_native.java
+++ b/java.base/src/main/java/sun/nio/fs/UnixNativeDispatcher$_native.java
@@ -528,30 +528,30 @@ class UnixNativeDispatcher$_native {
 
     private static void prepAttributes(final ptr<struct_stat> statBuf, final UnixFileAttributes attrs) {
         UnixFileAttributes$_aliases attrsAlias = (UnixFileAttributes$_aliases)(Object)attrs;
-        attrsAlias.st_mode = addr_of(statBuf.sel().st_mode).loadUnshared().intValue();
-        attrsAlias.st_ino = addr_of(statBuf.sel().st_ino).loadUnshared().longValue();
-        attrsAlias.st_dev = addr_of(statBuf.sel().st_dev).loadUnshared().longValue();
-        attrsAlias.st_rdev = addr_of(statBuf.sel().st_rdev).loadUnshared().longValue();
-        attrsAlias.st_nlink = addr_of(statBuf.sel().st_nlink).loadUnshared().intValue();
-        attrsAlias.st_uid = addr_of(statBuf.sel().st_uid).loadUnshared().intValue();
-        attrsAlias.st_gid = addr_of(statBuf.sel().st_gid).loadUnshared().intValue();
-        attrsAlias.st_size = addr_of(statBuf.sel().st_size).loadUnshared().longValue();
-        attrsAlias.st_atime_sec = addr_of(statBuf.sel().st_atime).loadUnshared().longValue();
-        attrsAlias.st_mtime_sec = addr_of(statBuf.sel().st_mtime).loadUnshared().longValue();
-        attrsAlias.st_ctime_sec = addr_of(statBuf.sel().st_ctime).loadUnshared().longValue();
+        attrsAlias.st_mode = statBuf.sel().st_mode.intValue();
+        attrsAlias.st_ino = statBuf.sel().st_ino.longValue();
+        attrsAlias.st_dev = statBuf.sel().st_dev.longValue();
+        attrsAlias.st_rdev = statBuf.sel().st_rdev.longValue();
+        attrsAlias.st_nlink = statBuf.sel().st_nlink.intValue();
+        attrsAlias.st_uid = statBuf.sel().st_uid.intValue();
+        attrsAlias.st_gid = statBuf.sel().st_gid.intValue();
+        attrsAlias.st_size = statBuf.sel().st_size.longValue();
+        attrsAlias.st_atime_sec = statBuf.sel().st_atime.longValue();
+        attrsAlias.st_mtime_sec = statBuf.sel().st_mtime.longValue();
+        attrsAlias.st_ctime_sec = statBuf.sel().st_ctime.longValue();
         // todo: if (defined(_DARWIN_FEATURE_64_BIT_INODE)) {
-        // todo:     attrs.st_birthtime = addr_of(statBuf.sel().st_birthtime).loadUnshared().longValue();
+        // todo:     attrs.st_birthtime = statBuf.sel().st_birthtime.longValue();
         // todo: }
         // --
         // todo: missing platform-dependent members
         // if (Build.Target.isMacOs()) {
-        //     attrs.st_atime_nsec = addr_of(statBuf.sel().st_atim.tv_nsec).loadUnshared().longValue();
-        //     attrs.st_mtime_nsec = addr_of(statBuf.sel().st_mtim.tv_nsec).loadUnshared().longValue();
-        //     attrs.st_ctime_nsec = addr_of(statBuf.sel().st_ctim.tv_nsec).loadUnshared().longValue();
+        //     attrs.st_atime_nsec = statBuf.sel().st_atim.tv_nsec.longValue();
+        //     attrs.st_mtime_nsec = statBuf.sel().st_mtim.tv_nsec.longValue();
+        //     attrs.st_ctime_nsec = statBuf.sel().st_ctim.tv_nsec.longValue();
         // } else {
-        //     attrs.st_atime_nsec = addr_of(statBuf.sel().st_atimespec.tv_nsec).loadUnshared().longValue();
-        //     attrs.st_mtime_nsec = addr_of(statBuf.sel().st_mtimespec.tv_nsec).loadUnshared().longValue();
-        //     attrs.st_ctime_nsec = addr_of(statBuf.sel().st_ctimespec.tv_nsec).loadUnshared().longValue();
+        //     attrs.st_atime_nsec = statBuf.sel().st_atimespec.tv_nsec).longValue();
+        //     attrs.st_mtime_nsec = statBuf.sel().st_mtimespec.tv_nsec.longValue();
+        //     attrs.st_ctime_nsec = statBuf.sel().st_ctimespec.tv_nsec.longValue();
         // }
     }
 


### PR DESCRIPTION
A series of improvements and bug fixes in qbicc now enable us to replace complex addr_of(p.sel().f).loadUnshared() code sequences with the much simpler expression p.sel().f.