### PR TITLE
eliminate reified pointer types from sys.bsd

### DIFF
--- a/java.base/src/main/java/java/lang/ProcessHandleImpl$Info$_patch.java
+++ b/java.base/src/main/java/java/lang/ProcessHandleImpl$Info$_patch.java
@@ -124,7 +124,7 @@ class ProcessHandleImpl$Info$_patch {
          */
         snprintf(addr_of(fn[0]), sizeof(fn), utf8z("/proc/%d/stat"), pid);
 
-        FILE_ptr fp = fopen(addr_of(fn[0]), utf8z("r"));
+        ptr<FILE> fp = fopen(addr_of(fn[0]), utf8z("r"));
         if (fp.isNull()) {
             return word(-1);              // fail, no such /proc/pid/stat
         }
@@ -134,8 +134,8 @@ class ProcessHandleImpl$Info$_patch {
          * As the command could be anything we must find the right most
          * ")" and then skip the white spaces that follow it.
          */
-        int statlen = fread(addr_of(buffer[0]).cast(), word(1), word(sizeof(buffer).intValue() - 1), fp).intValue();
-        fclose(fp);
+        int statlen = fread(addr_of(buffer[0]).cast(), word(1), word(sizeof(buffer).intValue() - 1), fp.cast()).intValue();
+        fclose(fp.cast());
         if (statlen < 0) {
             return word(-1);               // parent pid is not available
         }

--- a/java.base/src/main/java/java/lang/ProcessHandleImpl$Info$_runtime.java
+++ b/java.base/src/main/java/java/lang/ProcessHandleImpl$Info$_runtime.java
@@ -69,7 +69,7 @@ class ProcessHandleImpl$Info$_runtime {
         pageSize = sysconf(_SC_PAGE_SIZE).intValue();
 
         /* Read the boottime from /proc/stat. */
-        FILE_ptr fp = fopen(utf8z("/proc/stat"), utf8z("r"));
+        ptr<FILE> fp = fopen(utf8z("/proc/stat"), utf8z("r"));
         if (fp.isNull()) {
             bootTime_ms = -1;
         } else {
@@ -83,7 +83,7 @@ class ProcessHandleImpl$Info$_runtime {
                 }
             }
             free(line);
-            fclose(fp);
+            fclose(fp.cast());
             bootTime_ms = bootTime.longValue() * 1000;
         }
     }

--- a/java.base/src/main/java/java/net/Inet6AddressImpl$_qbicc.java
+++ b/java.base/src/main/java/java/net/Inet6AddressImpl$_qbicc.java
@@ -106,10 +106,10 @@ class Inet6AddressImpl$_qbicc {
              * exclude them in the normal case, but return them if we don't get an IP
              * address.
              */
-            for (struct_ifaddrs_ptr iter = ifa.cast(); !iter.isNull(); iter = iter.sel().ifa_next.cast()) {
+            for (ptr<struct_ifaddrs> iter = ifa; !iter.isNull(); iter = deref(iter).ifa_next) {
                 if (!iter.sel().ifa_addr.isNull()) {
                     int family = iter.sel().ifa_addr.sel().sa_family.intValue();
-                    if (addr_of(iter.sel().ifa_name).loadUnshared().asArray()[0] != word('\0')) {
+                    if (deref(iter).ifa_name.loadUnshared() != word('\0')) {
                         boolean isLoopback = (iter.sel().ifa_flags.intValue() & IFF_LOOPBACK.intValue()) != 0;
                         if (family == AF_INET.intValue()) {
                             addrs4++;
@@ -142,11 +142,11 @@ class Inet6AddressImpl$_qbicc {
             }
 
             // Now loop around the ifaddrs
-            for (struct_ifaddrs_ptr iter = ifa.cast(); !iter.isNull(); iter = iter.sel().ifa_next.cast()) {
+            for (ptr<struct_ifaddrs> iter = ifa; !iter.isNull(); iter = deref(iter).ifa_next) {
                 if (!iter.sel().ifa_addr.isNull()) {
                     int family = iter.sel().ifa_addr.sel().sa_family.intValue();
                     boolean isLoopback = (iter.sel().ifa_flags.intValue() & IFF_LOOPBACK.intValue()) != 0;
-                    if (addr_of(iter.sel().ifa_name).loadUnshared().asArray()[0] != word('\0') &&
+                    if (deref(iter).ifa_name.loadUnshared() != word('\0') &&
                             (family == AF_INET.intValue() || (family == AF_INET6.intValue() && includeV6)) &&
                             (!isLoopback || includeLoopback)) {
                         c_int port = auto();

--- a/java.base/src/main/java/java/net/NetworkInterface$_qbicc.java
+++ b/java.base/src/main/java/java/net/NetworkInterface$_qbicc.java
@@ -320,14 +320,14 @@ class NetworkInterface$_qbicc {
                 free(buf);
             }
         } else if (Build.Target.isMacOs()) {
-            struct_ifaddrs_ptr origifa = auto();
+            ptr<struct_ifaddrs> origifa = auto();
 
             if (getifaddrs(addr_of(origifa)).intValue() != 0) {
                 throw new SocketException("getifaddrs() failed");
             }
 
             try {
-                for (struct_ifaddrs_ptr ifa = origifa; !ifa.isNull(); ifa = ifa.sel().ifa_next.cast()) {
+                for (ptr<struct_ifaddrs> ifa = origifa; !ifa.isNull(); ifa = deref(ifa).ifa_next) {
                     ptr<struct_sockaddr> broadaddrP = word(0);
 
                     // ignore non IPv4 addresses

--- a/java.base/src/main/java/jdk/internal/sys/bsd/Ifaddrs.java
+++ b/java.base/src/main/java/jdk/internal/sys/bsd/Ifaddrs.java
@@ -7,17 +7,14 @@ import static jdk.internal.sys.posix.SysSocket.*;
 public class Ifaddrs {
     public static class struct_ifaddrs extends object {
         public ptr<struct_ifaddrs> ifa_next;
-        public char_ptr ifa_name;
+        public ptr<c_char> ifa_name;
         public unsigned_int ifa_flags;
-        public struct_sockaddr_ptr ifa_addr;
-        public struct_sockaddr_ptr ifa_netmask;
-        public struct_sockaddr_ptr ifa_dstaddr;
-        public void_ptr ifa_data;
+        public ptr<struct_sockaddr> ifa_addr;
+        public ptr<struct_sockaddr> ifa_netmask;
+        public ptr<struct_sockaddr> ifa_dstaddr;
+        public ptr<?> ifa_data;
     }
 
-    public static class struct_ifaddrs_ptr extends ptr<struct_ifaddrs> {}
-    public static class struct_ifaddrs_ptr_ptr extends ptr<struct_ifaddrs_ptr> {}
-
-    public static native c_int getifaddrs(struct_ifaddrs_ptr_ptr x);
-    public static native void freeifaddrs(struct_ifaddrs_ptr x);
+    public static native c_int getifaddrs(ptr<ptr<struct_ifaddrs>> x);
+    public static native void freeifaddrs(ptr<struct_ifaddrs> x);
 }

--- a/java.base/src/main/java/jdk/internal/sys/bsd/NetIf.java
+++ b/java.base/src/main/java/jdk/internal/sys/bsd/NetIf.java
@@ -4,5 +4,5 @@ import static org.qbicc.runtime.CNative.*;
 
 @include("<net/if.h>")
 public class NetIf {
-    public static native unsigned_int if_nametoindex(const_char_ptr ifname);
+    public static native unsigned_int if_nametoindex(ptr<@c_const c_char> ifname);
 }

--- a/java.base/src/main/java/jdk/internal/sys/bsd/SysEvent.java
+++ b/java.base/src/main/java/jdk/internal/sys/bsd/SysEvent.java
@@ -14,12 +14,10 @@ public class SysEvent {
         public uint16_t flags;
         public uint32_t fflags;
         public intptr_t data;
-        public void_ptr udata;
+        public ptr<?> udata;
     }
-
-    public static final class struct_kevent_ptr extends ptr<SysEvent.struct_kevent> {}
 
     public static native c_int kqueue();
 
-    public static native c_int kevent(c_int kq, struct_kevent_ptr changelist, c_int nchanges, struct_kevent_ptr eventlist, c_int nevents, const_struct_timespec_ptr timeout);
+    public static native c_int kevent(c_int kq, ptr<struct_kevent> changelist, c_int nchanges, ptr<struct_kevent> eventlist, c_int nevents, ptr<@c_const struct_timespec> timeout);
 }

--- a/java.base/src/main/java/jdk/internal/sys/bsd/SysProc.java
+++ b/java.base/src/main/java/jdk/internal/sys/bsd/SysProc.java
@@ -6,7 +6,7 @@ import static jdk.internal.sys.posix.SysTypes.*;
 @include("<sys/proc.h>")
 public class SysProc {
     public static final class struct_extern_proc extends object {
-        public void_ptr p_un; // union { struct { proc*; proc* } p_st1; timeval __p_starttime }
+        public ptr<?> p_un; // union { struct { proc*; proc* } p_st1; timeval __p_starttime }
         public pid_t p_pid;
     }
 }

--- a/java.base/src/main/java/jdk/internal/sys/bsd/SysSocket.java
+++ b/java.base/src/main/java/jdk/internal/sys/bsd/SysSocket.java
@@ -11,5 +11,5 @@ public class SysSocket {
 
     public static final class struct_sf_hdtr extends object { }
 
-    public static native c_int sendfile(c_int out_fd, c_int in_fd, off_t offset, off_t_ptr len, ptr<struct_sf_hdtr> hdtr, c_int flags);
+    public static native c_int sendfile(c_int out_fd, c_int in_fd, off_t offset, ptr<off_t> len, ptr<struct_sf_hdtr> hdtr, c_int flags);
 }

--- a/java.base/src/main/java/jdk/internal/sys/bsd/SysSysctl.java
+++ b/java.base/src/main/java/jdk/internal/sys/bsd/SysSysctl.java
@@ -21,7 +21,7 @@ public class SysSysctl {
         public uid_t cr_uid;
     }
 
-    public static native c_int sysctl(int_ptr name, unsigned_int nameLen, ptr<?> oldp, size_t_ptr oldlenp, ptr<?> newp, size_t newlen);
+    public static native c_int sysctl(ptr<c_int> name, unsigned_int nameLen, ptr<?> oldp, ptr<size_t> oldlenp, ptr<?> newp, size_t newlen);
 
     public static final c_int CTL_DEBUG = constant();
     public static final c_int CTL_VFS = constant();

--- a/java.base/src/main/java/sun/nio/ch/KQueue$_native.java
+++ b/java.base/src/main/java/sun/nio/ch/KQueue$_native.java
@@ -88,9 +88,9 @@ class KQueue$_native {
     }
 
     static int poll(int kqfd, long address, int nevents, long timeout) throws IOException {
-        struct_kevent_ptr events = word(address);
+        ptr<struct_kevent> events = word(address);
         struct_timespec ts = auto();
-        struct_timespec_ptr tsp = auto();
+        ptr<struct_timespec> tsp = auto();
 
         if (timeout >= 0) {
             ts.tv_sec = word(timeout/1000);
@@ -98,7 +98,7 @@ class KQueue$_native {
             tsp = addr_of(ts);
         }
 
-        c_int res = kevent(word(kqfd), word(0), word(0), events, word(nevents), tsp.cast());
+        c_int res = kevent(word(kqfd), word(0), word(0), events, word(nevents), tsp);
         if (res.intValue() < 0) {
             if (errno == EINTR.intValue()) {
                 return IOStatus.INTERRUPTED;


### PR DESCRIPTION
small cleanup; was able to test on my Mac via some kqueue and networking unit tests.

adding the casts in `fread` and `fclose` is a temporary workaround to hopefully get the library code to compile with both qbicc 0.68 and 0.69-SNAPSHOT. 