### PR TITLE
Fix stack traces, part 1: cache SP

### DIFF
--- a/java.base/src/main/java/java/lang/Throwable$_patch.java
+++ b/java.base/src/main/java/java/lang/Throwable$_patch.java
@@ -5,6 +5,7 @@ import static org.qbicc.runtime.CNative.*;
 import static org.qbicc.runtime.unwind.LibUnwind.*;
 
 import org.qbicc.runtime.Build;
+import org.qbicc.runtime.patcher.Add;
 import org.qbicc.runtime.patcher.PatchClass;
 import org.qbicc.runtime.patcher.Replace;
 import org.qbicc.runtime.stackwalk.JavaStackWalker;
@@ -17,6 +18,8 @@ import org.qbicc.runtime.stackwalk.StackWalker;
 final class Throwable$_patch {
     private transient Object backtrace;
     private transient int depth;
+    @Add
+    private ptr<?> sp;
 
     @Replace
     private Throwable fillInStackTrace(int ignored) {


### PR DESCRIPTION
Next, we'll update qbicc to store the SP at the moment of construction for any `Throwable` subclass. Finally, we'll update `Throwable$_patch` to skip over frames until the SP of the cursor is equal-to-or-higher-than the SP cached at instance creation time.