### PR TITLE
Semi-space garbage collector

### DIFF
--- a/java.base/src/main/java/java/lang/Object.java
+++ b/java.base/src/main/java/java/lang/Object.java
@@ -40,6 +40,7 @@ import org.qbicc.rt.annotation.Tracking;
 import org.qbicc.runtime.AutoQueued;
 import org.qbicc.runtime.Hidden;
 import org.qbicc.runtime.NoReflect;
+import org.qbicc.runtime.NoSafePoint;
 import org.qbicc.runtime.main.CompilerIntrinsics;
 import org.qbicc.runtime.main.Monitor;
 import org.qbicc.runtime.main.VMHelpers;
@@ -60,6 +61,7 @@ public class Object {
     @NoReflect
     int defaultHashCode;
 
+    @NoSafePoint // todo: skip safepoint check on empty methods/ctors
     public Object() {}
 
     public final Class<?> getClass() {

--- a/java.base/src/main/java/java/lang/Thread.java
+++ b/java.base/src/main/java/java/lang/Thread.java
@@ -1,21 +1,16 @@
 package java.lang;
 
 import static jdk.internal.sys.linux.Futex.*;
-import static jdk.internal.sys.posix.Errno.*;
 import static jdk.internal.sys.posix.Limits.*;
 import static jdk.internal.sys.posix.PThread.*;
 import static jdk.internal.sys.posix.Sched.*;
-import static jdk.internal.sys.posix.Time.*;
 
+import static jdk.internal.thread.ThreadNative.*;
 import static org.qbicc.runtime.CNative.*;
 import static org.qbicc.runtime.llvm.LLVM.*;
-import static org.qbicc.runtime.stdc.Errno.*;
 import static org.qbicc.runtime.stdc.Stdint.*;
 import static org.qbicc.runtime.stdc.Stdio.*;
 import static org.qbicc.runtime.stdc.Stdlib.*;
-import static org.qbicc.runtime.stdc.Time.*;
-import static org.qbicc.runtime.unwind.LibUnwind.*;
-import static org.qbicc.runtime.unwind.Unwind.*;
 
 import java.lang.module.ModuleDescriptor;
 import java.lang.ref.Reference;
@@ -25,12 +20,11 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
 import java.util.concurrent.TimeUnit;
-import java.util.concurrent.locks.LockSupport;
 
 import jdk.internal.misc.TerminatingThreadLocal;
 import jdk.internal.ref.CleanerFactory;
+import jdk.internal.thread.ThreadNative;
 import org.qbicc.rt.annotation.Tracking;
-import org.qbicc.runtime.AutoQueued;
 import org.qbicc.runtime.Build;
 import org.qbicc.runtime.Hidden;
 import org.qbicc.runtime.Inline;
@@ -38,7 +32,6 @@ import org.qbicc.runtime.InlineCondition;
 import org.qbicc.runtime.NoReturn;
 import org.qbicc.runtime.NoSafePoint;
 import org.qbicc.runtime.NoThrow;
-import org.qbicc.runtime.ThreadScoped;
 import org.qbicc.runtime.stackwalk.JavaStackWalker;
 import org.qbicc.runtime.stackwalk.StackWalker;
 import sun.nio.ch.Interruptible;
@@ -48,105 +41,6 @@ import sun.nio.ch.Interruptible;
  */
 @Tracking("src/java.base/share/classes/java/lang/Thread.java")
 public class Thread implements Runnable {
-
-    /**
-     * Holder class for the bound thread to avoid class circularity (thread containing thread-local variable).
-     */
-    static final class Bound {
-        /**
-         * Internal holder for the current thread.
-         */
-        @export
-        @ThreadScoped
-        static ptr<thread_native> _qbicc_bound_java_thread;
-    }
-
-    /**
-     * Mutex that protects the running thread doubly-linked list.
-     */
-    @SuppressWarnings("unused")
-    static final pthread_mutex_t thread_list_mutex = zero();
-
-    /**
-     * The special thread list terminus node.
-     */
-    static final thread_native thread_list_terminus = zero();
-
-    static {
-        thread_list_terminus.next = addr_of(thread_list_terminus);
-        thread_list_terminus.prev = addr_of(thread_list_terminus);
-    }
-
-    /**
-     * Structure containing thread-specific items which cannot be moved in memory.
-     * A doubly-linked list, protected by {@link #thread_list_mutex}, is maintained by
-     * the {@code next} and {@code prev} pointers, which are always non-{@code null}.
-     * The list link pointers may only be accessed (for read or write) under the mutex.
-     * The special node {@link #thread_list_terminus} indicates the start and end of the list.
-     * The {@code next} and {@code prev} pointers of that node contain the actual ends of the list.
-     * <p>
-     * This structure is allocated on thread start and freed some time after termination.
-     * Thus, it should normally only be accessed from the same thread or when thread state {@code STATE_ACTIVE} is set.
-     */
-    @internal
-    static class thread_native extends object {
-        // TODO
-        // ptr<?> top_of_stack; // basis for compressed stack refs
-        /**
-         * The next (newer) thread link.
-         * On the terminus node, this is the <em>first (least recent)</em> node in the list.
-         */
-        ptr<thread_native> next;
-        /**
-         * The previous (older) thread link.
-         * On the terminus node, this is the <em>last (most recent)</em> node in the list.
-         * New threads are added here.
-         */
-        ptr<thread_native> prev;
-
-        /**
-         * The POSIX thread identifier.
-         */
-        @incomplete(unless = Build.Target.IsPThreads.class)
-        pthread_t thread;
-
-        /**
-         * Reference to the actual Java thread. Must be updated during GC.
-         */
-        reference<Thread> ref;
-
-        // Fallback park/unpark mutex
-
-        /**
-         * Protects {@link #state} (double-checked path) and the two conditions on platforms without lockless waiting.
-         */
-        // todo: unless = Build.Target.HasIntegerWait or similar
-        @incomplete(when = {Build.Target.IsLinux.class, Build.Target.IsWasi.class}, unless = Build.Target.IsPosix.class)
-        pthread_mutex_t mutex;
-        /**
-         * Other threads signal this waiting thread.
-         */
-        @incomplete(when = {Build.Target.IsLinux.class, Build.Target.IsWasi.class}, unless = Build.Target.IsPosix.class)
-        pthread_cond_t inbound_cond;
-        /**
-         * This thread signals other waiting threads.
-         */
-        @incomplete(when = {Build.Target.IsLinux.class, Build.Target.IsWasi.class}, unless = Build.Target.IsPosix.class)
-        pthread_cond_t outbound_cond;
-
-        /**
-         * The thread state.
-         */
-        uint32_t state;
-
-        // safepoint state
-        @incomplete(when = Build.Target.IsWasi.class)
-        unw_context_t saved_context;
-
-        // exception info
-        // @incomplete(unless = Build.Target.IsUnwind.class)
-        struct__Unwind_Exception unwindException;
-    }
 
     final long stackSize;
     private volatile String name;
@@ -177,16 +71,6 @@ public class Thread implements Runnable {
     ptr<thread_native> threadNativePtr;
 
     /**
-     * Thread number counter for generation of thread names.
-     */
-    @SuppressWarnings("unused")
-    private static volatile int threadNumberCounter;
-
-    private static int nextThreadNum() {
-        return addr_of(threadNumberCounter).getAndAdd(word(1)).intValue();
-    }
-
-    /**
      * @see InheritableThreadLocal
      */
     ThreadLocal.ThreadLocalMap threadLocals = null;
@@ -201,19 +85,6 @@ public class Thread implements Runnable {
      */
     // must be named "tid" due to reference from Unsafe
     final long tid;
-
-    /* For generating thread ID */
-    @SuppressWarnings("unused")
-    private static volatile long threadSeqNumber;
-
-    /**
-     * The number of non-daemon threads; when this reaches zero, we exit.
-     */
-    @SuppressWarnings("unused")
-    private static volatile int nonDaemonThreadCount;
-
-    @SuppressWarnings("unused")
-    private static volatile int shutdownInitiated;
 
     // must be named "parkBlocker" due to reference from Unsafe
     @SuppressWarnings("unused")
@@ -245,220 +116,6 @@ public class Thread implements Runnable {
     public static final int MIN_PRIORITY = 1;
     public static final int NORM_PRIORITY = 5;
     public static final int MAX_PRIORITY = 10;
-
-    // JVMTI flag definitions; this is our thread state. Here are the constraints:
-    // - no more than one of STATE_WAITING, STATE_BLOCKED_ON_MONITOR_ENTER, or STATE_RUNNABLE may be set at once
-    // - no more than one of STATE_WAITING_INDEFINITELY or STATE_WAITING_WITH_TIMEOUT may be set at once
-    // - no more than one of STATE_IN_OBJECT_WAIT, STATE_PARKED, or STATE_SLEEPING may be set at once
-    // - if any of STATE_INTERRUPTED or STATE_IN_NATIVE is set, then STATE_ALIVE is set
-    // - no more than one of STATE_ALIVE or STATE_TERMINATED may be set at once
-
-    // ==================================
-    //  State Flags
-    //    These flag bits align with the
-    //    corresponding JVMTI bit numbers.
-    // ==================================
-    
-    // ----------------------------------
-    //  Liveness status flags
-    //    0 or 1 of these may be set
-    // ----------------------------------
-
-    /**
-     * Thread is alive (has been started).
-     * Mutually exclusive with {@link #STATE_TERMINATED}.
-     */
-    static final int STATE_ALIVE = 1 << 0;
-    /**
-     * Thread is terminated (has exited after being started).
-     * Mutually exclusive with {@link #STATE_ALIVE}.
-     */
-    static final int STATE_TERMINATED = 1 << 1;
-
-    // ----------------------------------
-    //  Terminated state flags
-    //    0 or 1 of these may be set
-    //    (STATE_TERMINATED is set)
-    // ----------------------------------
-
-    /**
-     * Thread has exited.
-     * May only be set while {@link #STATE_TERMINATED} is set.
-     */
-    static final int STATE_EXITED = 1 << 27;
-
-    // ----------------------------------
-    //  Alive state flags
-    //    Exactly 1 must be set
-    //    (STATE_ALIVE is set)
-    // ----------------------------------
-
-    /**
-     * Thread is runnable.
-     * May only be set while {@link #STATE_ALIVE} is set.
-     * Mutually exclusive with {@link #STATE_WAITING} and {@link #STATE_BLOCKED_ON_MONITOR_ENTER}.
-     */
-    static final int STATE_RUNNABLE = 1 << 2;
-    /**
-     * The thread is waiting for something (is not currently runnable).
-     * May only be set while {@link #STATE_ALIVE} is set.
-     * Mutually exclusive with {@link #STATE_RUNNABLE} and {@link #STATE_BLOCKED_ON_MONITOR_ENTER}.
-     */
-    static final int STATE_WAITING = 1 << 7;
-    /**
-     * The thread is blocked waiting to acquire or reacquire an object monitor.
-     * May only be set while {@link #STATE_ALIVE} is set.
-     * Mutually exclusive with {@link #STATE_RUNNABLE} and {@link #STATE_WAITING}.
-     */
-    static final int STATE_BLOCKED_ON_MONITOR_ENTER = 1 << 10;
-
-    // ----------------------------------
-    //  Waiting reason flags
-    //    0 or 1 may be set while WAITING
-    // ----------------------------------
-
-    /**
-     * The thread is waiting without a timeout.
-     * May only be set while {@link #STATE_WAITING} is set.
-     * Mutually exclusive with {@link #STATE_WAITING_WITH_TIMEOUT}.
-     */
-    static final int STATE_WAITING_INDEFINITELY = 1 << 4;
-    /**
-     * The thread is waiting with a timeout.
-     * May only be set while {@link #STATE_WAITING} is set.
-     * Mutually exclusive with {@link #STATE_WAITING_INDEFINITELY}.
-     */
-    static final int STATE_WAITING_WITH_TIMEOUT = 1 << 5;
-    /**
-     * The thread is asleep (i.e. in {@link #sleep(long)} or {@link #sleep(long, int)}).
-     * May only be set while {@link #STATE_WAITING} is set.
-     * Mutually exclusive with {@link #STATE_IN_OBJECT_WAIT} and {@link #STATE_PARKED}.
-     */
-    static final int STATE_SLEEPING = 1 << 6;
-    /**
-     * The thread is waiting on an object's monitor.
-     * May only be set while {@link #STATE_WAITING} is set.
-     * Mutually exclusive with {@link #STATE_SLEEPING} and {@link #STATE_PARKED}.
-     */
-    static final int STATE_IN_OBJECT_WAIT = 1 << 8;
-    /**
-     * The thread is waiting in one of the {@link LockSupport} park methods.
-     * May only be set while {@link #STATE_WAITING} is set.
-     * Mutually exclusive with {@link #STATE_SLEEPING} and {@link #STATE_IN_OBJECT_WAIT}.
-     */
-    static final int STATE_PARKED = 1 << 9;
-    // STATE_SUSPENDED = 1 << 20;
-
-    // ----------------------------------
-    //  Run-time notification flags
-    //    0 or more may be set while ALIVE
-    //    Affects running thread state
-    // ----------------------------------
-
-    /**
-     * The unpark permit.
-     * If set, then a {@code LockSupport.park()} will consume the permit rather than park.
-     * Other forms of {@code park} and other blocking operations are unaffected.
-     * May only be set while {@link #STATE_ALIVE} is set.
-     * Normally clear.
-     * This is an inbound-notification flag.
-     * This bit is unused by JVMTI.
-     */
-    static final int STATE_UNPARK = 1 << 11; // unused by JVMTI
-    /**
-     * The interrupt flag.
-     * If set, then interruptible blocking operations will return immediately or throw an interruption exception.
-     * Other blocking operations are unaffected.
-     * May only be set while {@link #STATE_ALIVE} is set.
-     * Normally clear.
-     * This is an inbound-notification flag.
-     */
-    static final int STATE_INTERRUPTED = 1 << 21;
-
-    // ----------------------------------
-    //  Thread safepoint state flags
-    // ----------------------------------
-
-    /**
-     * The in-native flag.
-     * If set, then a native method is running.
-     * Native methods may also run without setting this flag.
-     * May only be set while {@link #STATE_IN_SAFEPOINT} is set.
-     * Normally clear.
-     * No notifications are associated with this flag.
-     */
-    static final int STATE_IN_NATIVE = 1 << 22;
-    /**
-     * The in-safepoint flag.
-     * If set, then the thread is in a safepoint.
-     * A thread may cooperatively enter a safepoint at any time.
-     * A thread may not exit the safepoint state until the {@link #STATE_SAFEPOINT_REQUEST} flag is clear.
-     * May only be set while {@link #STATE_ALIVE} is set.
-     * This is an outbound-notification flag.
-     * This bit corresponds to the JVMTI "vendor 1" bit.
-     */
-    static final int STATE_IN_SAFEPOINT = 1 << 28;
-
-    // ----------------------------------
-    //  Thread safepoint request flags
-    // ----------------------------------
-
-    /**
-     * The safepoint-request flag for GC.
-     * If set, then the thread is participating in garbage collection and may not exit a safepoint.
-     * Normally clear.
-     * The thread may atomically set its own request-GC flag and park in a safepoint if it cannot complete an allocation.
-     * The GC thread(s) may set this flag and perform GC work from within a safepoint.
-     * May only be set while {@link #STATE_ALIVE} is set.
-     * No notifications are associated with this flag.
-     * This bit corresponds to the JVMTI "vendor 2" bit.
-     */
-    static final int STATE_SAFEPOINT_REQUEST_GC = 1 << 29;
-    /**
-     * The safepoint-request flag for thread stack walking.
-     * If set, then the thread is participating in stack capture and may not exit a safepoint.
-     * This flag must be owned exclusively by one thread to prevent premature safepoint exits.
-     * Use a monitor to ensure exclusive access.
-     * Normally clear.
-     * May only be set while {@link #STATE_ALIVE} is set.
-     * No notifications are associated with this flag.
-     * This bit corresponds to the JVMTI "vendor 3" bit.
-     */
-    static final int STATE_SAFEPOINT_REQUEST_STACK = 1 << 30;
-    // STATE_SAFEPOINT_REQUEST_SUSPEND = 1 << ??;
-    /**
-     * The general safepoint-request flag.
-     * This flag must be set whenever any of the other {@code #PARK_SAFEPOINT_REQUEST_*} flags are set.
-     * This is because CPUs generally have a single instruction to detect a negative number, making polling more efficient.
-     * May only be set while {@link #STATE_ALIVE} is set.
-     * This is an inbound-notification flag.
-     * This bit is unused by JVMTI.
-     */
-    static final int STATE_SAFEPOINT_REQUEST = 1 << 31;
-
-    /**
-     * The thread state bit mask which reflects the bits that are valid to JVMTI.
-     */
-    static final int JVMTI_STATE_BITS = 0
-        | STATE_ALIVE
-        | STATE_TERMINATED
-        | STATE_RUNNABLE
-        | STATE_WAITING_INDEFINITELY
-        | STATE_WAITING_WITH_TIMEOUT
-        | STATE_SLEEPING
-        | STATE_WAITING
-        | STATE_IN_OBJECT_WAIT
-        | STATE_PARKED
-        | STATE_BLOCKED_ON_MONITOR_ENTER
-     // | STATE_SUSPENDED
-        | STATE_INTERRUPTED
-        | STATE_IN_NATIVE
-        ;
-
-    /**
-     * A mask containing the bits of all the specific safepoint-request flags.
-     */
-    static final int STATE_SAFEPOINT_REQUEST_ANY = STATE_SAFEPOINT_REQUEST_GC | STATE_SAFEPOINT_REQUEST_STACK;
 
     private static final StackTraceElement[] EMPTY_STACK_TRACE = new StackTraceElement[0];
 
@@ -624,7 +281,6 @@ public class Thread implements Runnable {
             free(threadNativePtr);
             throw new IllegalThreadStateException();
         }
-        Bound._qbicc_bound_java_thread = threadNativePtr;
 
         // now, the tricky part: we have to add this thread to the big linked list
         final ptr<thread_native> currentThreadNativePtr = Thread.currentThread().threadNativePtr;
@@ -727,19 +383,6 @@ public class Thread implements Runnable {
         // started!
     }
 
-    private static void notifySafePointOutbound(final ptr<thread_native> threadNativePtr) {
-        final ptr<uint32_t> statePtr = addr_of(deref(threadNativePtr).state);
-        if (Build.Target.isLinux()) {
-            futex_wake_all(statePtr);
-        } else if (Build.Target.isWasi()) {
-            // TODO
-            //  memory.atomic.notify(statusPtr, 1)
-            abort();
-        } else if (Build.Target.isPosix()) {
-            if (pthread_cond_signal(addr_of(deref(threadNativePtr).outbound_cond)).isNonZero()) abort();
-        }
-    }
-
     @NoSafePoint
     @Hidden
     @NoThrow
@@ -767,7 +410,7 @@ public class Thread implements Runnable {
         }
         final ptr<thread_native> threadNativePtr = this.threadNativePtr;
         final ptr<pthread_t> pthreadPtr = addr_of(deref(threadNativePtr).thread);
-        final ptr<function<pthread_run>> run_fn = addr_of(function.of(Thread::runThreadBody));
+        final ptr<function<pthread_run>> run_fn = addr_of(function.of(ThreadNative::runThreadBody));
         // todo: safepoint while thread is created?
         result = pthread_create(pthreadPtr, addr_of(thread_attr), run_fn, threadNativePtr.cast()).intValue();
         pthread_attr_destroy(addr_of(thread_attr));
@@ -1097,144 +740,6 @@ public class Thread implements Runnable {
     //  Private
     // ==================================
 
-    static void monitorEnter(Object obj) {
-        if (obj == null) {
-            throw new NullPointerException();
-        }
-        // todo: stack-locking or similar
-        Object$_aliases oa = cast(obj);
-        oa.monitorEnter();
-    }
-
-    static void monitorExit(Object obj) {
-        if (obj == null) {
-            throw new NullPointerException();
-        }
-        // todo: stack-locking or similar
-        Object$_aliases oa = cast(obj);
-        oa.monitorExit();
-    }
-
-    /**
-     * A pointer to this function is passed to pthread_create by start0.
-     * The role of this wrapper is to transition a newly started Thread from C to Java calling
-     * conventions and then invoke the Thread's run0 method.
-     * @param threadParam a reference stuffed into a pointer
-     * @return {@code null} always
-     */
-    @export(withScope = ExportScope.LOCAL)
-    @Hidden
-    static ptr<?> runThreadBody(ptr<?> threadParam) {
-        pthread_detach(pthread_self());
-        ptr<thread_native> threadNativePtr = threadParam.cast();
-        Bound._qbicc_bound_java_thread = threadNativePtr;
-        bind(threadNativePtr);
-        // not reachable
-        abort();
-        return null;
-    }
-
-    /**
-     * Attach an unstarted thread and run the given method body under the thread.
-     *
-     * @param thread the thread to attach
-     */
-    @export
-    @NoThrow
-    @Hidden
-    private static void thread_attach(Thread thread) {
-        ptr<thread_native> threadNativePtr = thread.threadNativePtr;
-        if (threadNativePtr.isNonNull()) {
-            // we cannot recover
-            abort();
-        }
-        threadNativePtr = malloc(sizeof(thread_native.class));
-        if (threadNativePtr.isNull()) {
-            // not enough memory to start
-            abort();
-        }
-        // zero-init the whole structure
-        threadNativePtr.storeUnshared(zero());
-        if (Build.Target.isPosix()) {
-            if (! Build.Target.isLinux() && ! Build.Target.isWasm()) {
-                if (pthread_mutex_init(addr_of(deref(threadNativePtr).mutex), zero()).isNonZero()) abort();
-                if (pthread_cond_init(addr_of(deref(threadNativePtr).inbound_cond), zero()).isNonZero()) abort();
-                if (pthread_cond_init(addr_of(deref(threadNativePtr).outbound_cond), zero()).isNonZero()) abort();
-            }
-        }
-        deref(threadNativePtr).ref = reference.of(thread);
-        // register it on to this thread *before* the safepoint
-        if (addr_of(deref(refToPtr(thread)).threadNativePtr).compareAndSwap(zero(), threadNativePtr).isNonNull()) {
-            // lost the race :(
-            // release the mutex and conditions
-            if (Build.Target.isPosix()) {
-                if (! Build.Target.isLinux() && ! Build.Target.isWasm()) {
-                    if (pthread_cond_destroy(addr_of(deref(threadNativePtr).outbound_cond)).isNonZero()) abort();
-                    if (pthread_cond_destroy(addr_of(deref(threadNativePtr).inbound_cond)).isNonZero()) abort();
-                    if (pthread_mutex_destroy(addr_of(deref(threadNativePtr).mutex)).isNonZero()) abort();
-                }
-            }
-            free(threadNativePtr);
-            abort();
-        }
-        Bound._qbicc_bound_java_thread = threadNativePtr;
-
-        // initialize status
-        deref(threadNativePtr).state = word(STATE_ALIVE);
-
-        int oldVal;
-        int newVal;
-        int witness;
-
-        // lock in the config
-        final ptr<int32_t> configPtr = addr_of(deref(refToPtr(thread)).config);
-        oldVal = configPtr.loadSingleAcquire().intValue();
-        for (;;) {
-            if ((oldVal & CONFIG_LOCKED) != 0) {
-                // should not be possible, but it's a valid state
-                if ((oldVal & CONFIG_DAEMON) != 0) {
-                    // the main thread may not be a daemon thread
-                    abort();
-                }
-                break;
-            }
-            newVal = oldVal | CONFIG_LOCKED;
-            witness = configPtr.compareAndSwapRelease(word(oldVal), word(newVal)).intValue();
-            if (witness == oldVal) {
-                break;
-            }
-            oldVal = witness;
-        }
-        // manually register the thread count
-        addr_of(nonDaemonThreadCount).getAndAdd(word(1));
-
-        // add thread to linked list; note that unlike `start`, we do not safepoint here
-        // acquire lock
-        if (Build.Target.isPosix()) {
-            if (pthread_mutex_lock(addr_of(thread_list_mutex)).isNonZero()) abort();
-        } else {
-            // ???
-            abort();
-        }
-        // we hold the big list lock; do ye olde linked list insertion
-        deref(thread_list_terminus.prev).next = threadNativePtr;
-        deref(threadNativePtr).prev = thread_list_terminus.prev;
-        thread_list_terminus.prev = threadNativePtr;
-        deref(threadNativePtr).next = addr_of(thread_list_terminus);
-        // release lock
-        if (Build.Target.isPosix()) {
-            if (pthread_mutex_unlock(addr_of(thread_list_mutex)).isNonZero()) abort();
-        } else {
-            // ???
-            abort();
-        }
-
-        // The thread is now alive; use the normal execution methodology from now on
-        bind(threadNativePtr);
-        // (not reachable)
-        abort();
-    }
-
     @NoReturn
     void end() {
         Thread self = this;
@@ -1279,34 +784,6 @@ public class Thread implements Runnable {
             pthread_exit(zero());
         }
     }
-
-    private static void exitNonDaemonThread() {
-        // todo: put the shutdown bit right on the count word?
-        int cnt = addr_of(nonDaemonThreadCount).getAndAdd(word(- 1)).intValue();
-        if (cnt == 1) {
-            boolean shouldShutdown = addr_of(shutdownInitiated).compareAndSet(word(0), word(1));
-            if (shouldShutdown) {
-                // start a new exiter thread to avoid blocking Thread.start()
-                new Thread(() -> Shutdown.exit(0), "Exit thread").start();
-            }
-        }
-    }
-
-    @NoSafePoint
-    static void freeThreadNative(ptr<thread_native> threadNativePtr) {
-        // assert threadNativePtr != null;
-        if (Build.Target.isPosix() && ! Build.Target.isLinux() && ! Build.Target.isWasm()) {
-            // destroy our conditions and mutex
-            pthread_cond_destroy(addr_of(deref(threadNativePtr).inbound_cond));
-            pthread_cond_destroy(addr_of(deref(threadNativePtr).outbound_cond));
-            pthread_mutex_destroy(addr_of(deref(threadNativePtr).mutex));
-        }
-        // release the memory
-        free(threadNativePtr);
-    }
-
-    // intrinsic, but implies Hidden & NoThrow & NoReturn
-    static native void bind(ptr<thread_native> threadPtr);
 
     @SuppressWarnings("unused") // called by `bind`
     @Hidden
@@ -1370,123 +847,8 @@ public class Thread implements Runnable {
         }
     }
 
-    // Park/unpark
-    @NoSafePoint
-    private static long nextThreadID() {
-        return addr_of(threadSeqNumber).getAndAdd(word(1)).longValue();
-    }
-
     /**
-     * Park in a safepoint for some amount of time.
-     *
-     * @param millis the number of milliseconds to park for
-     * @param nanos the number of nanos to park for
-     * @param setBits the bits to set while parking
-     * @param clearBits the bits to clear while parking
-     * @param wakeBits the set of bits, any of which should cause the park to return early
-     * @param clearWakeBits the set of bits to clear on unpark and cause the park to return early
-     */
-    @SuppressWarnings("ConstantConditions")
-    @NoSafePoint
-    @Hidden
-    static void park(long millis, int nanos, int setBits, int clearBits, int wakeBits, int clearWakeBits) {
-        if (millis < 0 || nanos < 0 || nanos > 999_999) {
-            throw new IllegalArgumentException();
-        }
-        // assert
-        final ptr<thread_native> threadNativePtr = Thread.currentThread().threadNativePtr;
-        final ptr<uint32_t> statePtr = addr_of(deref(threadNativePtr).state);
-        // check to see if we should just exit right away
-        if ((statePtr.loadSingleAcquire().intValue() & wakeBits) != 0) {
-            return;
-        }
-        if (Build.Target.isPosix()) {
-            // POSIX park uses seconds not millis...
-            long posixSeconds = millis / 1_000L;
-            int posixNanos = nanos + ((int)millis % 1_000) * 1_000_000;
-            parkPosix(posixSeconds, posixNanos, setBits, clearBits, wakeBits, clearWakeBits);
-        } else {
-            // todo
-            abort();
-        }
-    }
-
-    @SuppressWarnings("ConstantConditions")
-    @NoSafePoint
-    @NoThrow
-    @Hidden
-    private static void parkPosix(long seconds, int nanos, int setBits, int clearBits, int wakeBits, int clearWakeBits) {
-        struct_timespec ts = auto();
-        struct_timespec now = auto();
-        final ptr<thread_native> threadNativePtr = Thread.currentThread().threadNativePtr;
-        final ptr<uint32_t> statePtr = addr_of(deref(threadNativePtr).state);
-        enterSafePoint(threadNativePtr, setBits, clearBits);
-        // we are now ready to park
-
-        // wait for any of the bits to be set
-        if (! Build.Target.isLinux()) {
-            // acquire the mutex
-            if (pthread_mutex_lock(addr_of(deref(threadNativePtr).mutex)).isNonZero()) abort();
-        }
-        if (seconds != 0 || nanos != 0) {
-            // get the start time; both Linux and not-linux are absolute but the clock used varies
-            clock_gettime(Build.Target.isLinux() ? CLOCK_MONOTONIC : CLOCK_REALTIME, addr_of(now));
-            // add the base time to the duration
-            nanos += now.tv_nsec.intValue();
-            if (nanos > 1_000_000_000) {
-                // carry the one
-                seconds ++;
-                nanos -= 1_000_000_000;
-            }
-            seconds += now.tv_sec.longValue();
-            // store it back
-            ts.tv_sec = word(seconds);
-            ts.tv_nsec = word(nanos);
-        }
-        wakeBits |= clearWakeBits;
-        int oldVal = statePtr.loadSingleAcquire().intValue();
-        while ((oldVal & wakeBits) == 0) {
-            // wait
-            if (seconds != 0 || nanos != 0) {
-                if (Build.Target.isLinux()) {
-                    futex_wait_bits(statePtr, word(wakeBits), word(wakeBits), addr_of(ts));
-                } else {
-                    final c_int res = pthread_cond_timedwait(addr_of(deref(threadNativePtr).inbound_cond), addr_of(deref(threadNativePtr).mutex), addr_of(ts));
-                    if (res.isNonZero() && res != ETIMEDOUT) abort();
-                }
-            } else {
-                if (Build.Target.isLinux()) {
-                    futex_wait_bits(statePtr, word(wakeBits), word(wakeBits), zero());
-                } else {
-                    if (pthread_cond_wait(addr_of(deref(threadNativePtr).inbound_cond), addr_of(deref(threadNativePtr).mutex)).isNonZero()) abort();
-                }
-            }
-            // check the bits
-            oldVal = statePtr.loadSingleAcquire().intValue();
-            if ((oldVal & wakeBits) != 0) {
-                // done (awoken)
-                break;
-            }
-            if (seconds != 0 || nanos != 0) {
-                // check the time
-                clock_gettime(Build.Target.isLinux() ? CLOCK_MONOTONIC : CLOCK_REALTIME, addr_of(now));
-                if (now.tv_sec.longValue() > ts.tv_sec.longValue() || now.tv_sec == ts.tv_sec && now.tv_nsec.intValue() >= ts.tv_nsec.intValue()) {
-                    // done (timeout)
-                    break;
-                }
-            }
-        }
-        // unlock
-        if (! Build.Target.isLinux()) {
-            // release the mutex
-            if (pthread_mutex_unlock(addr_of(deref(threadNativePtr).mutex)).isNonZero()) abort();
-        }
-        // todo: this reacquires the mutex right away; maybe introduce a "locked" version to avoid this
-        exitSafePoint(threadNativePtr, clearBits, setBits | clearWakeBits);
-    }
-
-    /**
-     * Attempt to interrupt a {@link #park(long, int, int, int, int, int)} operation.
+     * Attempt to interrupt a {@link ThreadNative#park(long, int, int, int, int, int)} operation.
      *
      * @param wakeBits the wakeup bits to set on the target thread
      */
@@ -1542,290 +904,6 @@ public class Thread implements Runnable {
      */
     static void blockedOn(Interruptible b) {
         Thread.currentThread().blocker = b;
-    }
-
-    /**
-     * Request that a thread enter into a safepoint.
-     * Within a safepoint, a thread may not access the VM heap in any way (including allocation).
-     * On return, the thread was requested to enter a safepoint.
-     *
-     * @param setBits the {@code STATE_*} flag that indicates the reason for the safepoint
-     */
-    @NoSafePoint
-    @Hidden
-    @NoThrow
-    static void requestSafePoint(ptr<thread_native> threadNativePtr, int setBits) {
-        // assert Integer.bitCount(reason) == 1;
-        // assert Thread.currentThread() != threadNativePtr->ref
-        final ptr<uint32_t> statusPtr = addr_of(deref(threadNativePtr).state);
-        setBits |= STATE_SAFEPOINT_REQUEST;
-        int witness;
-        int oldVal = statusPtr.loadVolatile().intValue();
-        for (;;) {
-            if ((oldVal & setBits) == setBits) {
-                // already set
-                return;
-            }
-            witness = statusPtr.compareAndSwap(word(oldVal), word(oldVal | setBits)).intValue();
-            if (witness == oldVal) {
-                // done
-                return;
-            }
-            oldVal = witness;
-        }
-    }
-
-    /**
-     * Release a safepoint for another thread.
-     * The bits given should be the same as the one given to {@link #requestSafePoint}.
-     *
-     * @param clearBits the {@code STATE_*} flag that indicates the reason for the safepoint
-     */
-    @NoSafePoint
-    @Hidden
-    @NoThrow
-    static void releaseSafePoint(final ptr<thread_native> threadNativePtr, int clearBits) {
-        // assert Integer.bitCount(reason) == 1;
-        final ptr<uint32_t> statusPtr = addr_of(deref(threadNativePtr).state);
-        int witness;
-        int oldVal = statusPtr.loadVolatile().intValue();
-        int newVal;
-        for (;;) {
-            newVal = oldVal & ~clearBits;
-            if ((newVal & STATE_SAFEPOINT_REQUEST_ANY) == 0) {
-                // case 1: we were the last reason for safepoint
-                newVal &= ~STATE_SAFEPOINT_REQUEST;
-                witness = statusPtr.compareAndSwap(word(oldVal), word(newVal)).intValue();
-                if (witness == oldVal) {
-                    // done; now we must signal the thread so it can exit the safepoint
-                    if (Build.Target.isLinux()) {
-                        futex_wake_all(statusPtr);
-                    } else if (Build.Target.isWasi()) {
-                        // TODO
-                        //  memory.atomic.notify(statusPtr, 1)
-                        abort();
-                    } else if (Build.Target.isPosix()) {
-                        if (pthread_cond_signal(addr_of(deref(threadNativePtr).inbound_cond)).isNonZero()) abort();
-                    }
-                    return;
-                }
-            } else {
-                // case 2: other safepoint reasons are still in effect; just clear the bit and return
-                witness = statusPtr.compareAndSwap(word(oldVal), word(newVal)).intValue();
-                if (witness == oldVal) {
-                    // done
-                    return;
-                }
-            }
-            oldVal = witness;
-        }
-    }
-
-    /**
-     * Wait until the given thread is in a safepoint.
-     * Must not be called from within the same thread.
-     * May only be called within a safepoint.
-     */
-    @NoSafePoint
-    @Hidden
-    @NoThrow
-    static void awaitSafePoint(ptr<thread_native> threadNative) {
-        awaitStatusWord(threadNative, STATE_IN_SAFEPOINT);
-    }
-
-    @NoSafePoint
-    @Hidden
-    @NoThrow
-    static void awaitStatusWord(ptr<thread_native> threadNative, int bits) {
-        awaitStatusWord(threadNative, bits, bits);
-    }
-
-    @NoSafePoint
-    @Hidden
-    @NoThrow
-    static int awaitStatusWord(ptr<thread_native> threadNative, int mask, int bits) {
-        // assert isSafePoint();
-        final ptr<uint32_t> statusPtr = addr_of(deref(threadNative).state);
-        int state = statusPtr.loadVolatile().intValue();
-        while ((state & mask) != bits) {
-            if (Build.Target.isLinux()) {
-                // use futex operations to await our desired bit pattern
-                if (! futex_wait_bits(statusPtr, word(mask), word(bits), zero()) && errno != EINTR.intValue()) {
-                    // fatal error
-                    abort();
-                }
-            } else if (Build.Target.isWasi()) {
-                // TODO
-                //  memory.atomic.wait32(statusPtr, state & mask | bits, -1)
-                abort();
-            } else if (Build.Target.isPosix()) {
-                // double-checked pattern, but using pthread_mutex
-                int res = pthread_mutex_lock(addr_of(deref(threadNative).mutex)).intValue();
-                if (res != 0) {
-                    // fatal error
-                    abort();
-                }
-                state = statusPtr.loadVolatile().intValue();
-                while ((state & mask) != bits) {
-                    res = pthread_cond_wait(addr_of(deref(threadNative).outbound_cond), addr_of(deref(threadNative).mutex)).intValue();
-                    if (res != 0) {
-                        // fatal error
-                        abort();
-                    }
-                    state = statusPtr.loadVolatile().intValue();
-                }
-                res = pthread_mutex_unlock(addr_of(deref(threadNative).mutex)).intValue();
-                if (res != 0) {
-                    // fatal error
-                    abort();
-                }
-                // done by interior loop
-                return state;
-            }
-            state = statusPtr.loadVolatile().intValue();
-        }
-        return state;
-    }
-
-    /**
-     * Poll for a safepoint.
-     */
-    @NoSafePoint
-    @Hidden
-    @Inline(InlineCondition.ALWAYS)
-    @NoThrow
-    @AutoQueued
-    static void pollSafePoint() {
-        final ptr<thread_native> threadNativePtr = currentThread().threadNativePtr;
-        final int threadStatus = addr_of(deref(threadNativePtr).state).loadAcquire().intValue();
-        if (threadStatus < 0) {
-            externalSafePoint(threadNativePtr);
-        }
-    }
-
-    /**
-     * Do the work of an externally-triggered safepoint.
-     */
-    @NoSafePoint
-    @Hidden
-    @Inline(InlineCondition.NEVER)
-    @NoThrow
-    private static void externalSafePoint(final ptr<thread_native> threadNativePtr) {
-        enterSafePoint(threadNativePtr, 0, 0);
-        exitSafePoint(threadNativePtr, 0, 0);
-    }
-
-    /**
-     * Enter a safepoint voluntarily from the current thread.
-     * While in a safepoint, the thread execution state will not change.
-     * However, the interrupt or unpark flags may be asynchronously set on a safepointed thread.
-     * The {@code reason} parameter must either be zero or a combination of {@link #STATE_SAFEPOINT_REQUEST} and
-     * one or more {@code PARK_SAFEPOINT_REQUEST_*} flags; otherwise, the thread will be trapped in a safepoint indefinitely.
-     *
-     * @param threadNativePtr the pointer to the thread's native structure (must not be {@code null})
-     * @param setBits an optional set of bits to add to the status
-     * @param clearBits an optional set of bits to remove from the status
-     */
-    @NoSafePoint
-    @Hidden
-    @NoThrow
-    static void enterSafePoint(ptr<thread_native> threadNativePtr, int setBits, int clearBits) {
-        // XXX WARNING: Thread.currentThread() is INVALID in this method XXX
-        // the reason is that GC may relocate it, but this method is not in the captured context so stack walk will miss it
-
-        final ptr<uint32_t> statusPtr = addr_of(deref(threadNativePtr).state);
-
-        // capture our state
-        // todo: if (Build.Target.isUnwContext) ...
-        if (unw_getcontext(addr_of(deref(threadNativePtr).saved_context)).isNonZero()) abort();
-
-        // now, indicate that we are in a safepoint
-        int witness = statusPtr.loadVolatile().intValue();
-        int oldVal, newVal;
-        do {
-            oldVal = witness;
-            // no need to check oldVal, since we cannot be in a safepoint
-            // assert (oldVal & (STATE_EXITED | STATE_IN_SAFEPOINT)) == 0;
-            newVal = oldVal | STATE_IN_SAFEPOINT | setBits;
-            witness = statusPtr.compareAndSwap(word(oldVal), word(newVal)).intValue();
-        } while (witness != oldVal);
-        // notify waiters (if any)
-        if (Build.Target.isLinux()) {
-            futex_wake_all(statusPtr);
-        } else if (Build.Target.isWasi()) {
-            // TODO
-            //  memory.atomic.notify(statusPtr, Integer.MAX_VALUE)
-            abort();
-        } else if (Build.Target.isPosix()) {
-            // signal after transition
-            if (pthread_cond_broadcast(addr_of(deref(threadNativePtr).outbound_cond)).intValue() != 0) abort();
-        }
-    }
-
-    @NoSafePoint
-    @Hidden
-    static int exitSafePoint(ptr<thread_native> threadNativePtr, int setBits, int clearBits) {
-        // XXX WARNING: Thread.currentThread() is INVALID in this method XXX
-        // the reason is that GC may relocate it, but this method is not in the captured context so stack walk will miss it
-
-        final ptr<uint32_t> statusPtr = addr_of(deref(threadNativePtr).state);
-        // wait until it's OK to exit the safepoint
-        // assert isSafePoint();
-        if (Build.Target.isPosix() && ! Build.Target.isLinux() && ! Build.Target.isWasi()) {
-            // double-checked pattern, but using pthread_mutex; also, we need the lock for waiting
-            int res = pthread_mutex_lock(addr_of(deref(threadNativePtr).mutex)).intValue();
-            if (res != 0) {
-                // fatal error
-                abort();
-            }
-        }
-        int oldVal = statusPtr.loadVolatile().intValue();
-        for (;;) {
-            while ((oldVal & STATE_SAFEPOINT_REQUEST) != 0) {
-                if (Build.Target.isLinux()) {
-                    // use futex operations to await our desired bit pattern
-                    if (! futex_wait_bits(statusPtr, word(STATE_SAFEPOINT_REQUEST), word(0), zero()) && errno != EINTR.intValue()) {
-                        // fatal error
-                        abort();
-                    }
-                } else if (Build.Target.isWasi()) {
-                    // TODO
-                    //  memory.atomic.wait32(statusPtr, state & ~STATE_SAFEPOINT_REQUEST, -1)
-                    abort();
-                } else if (Build.Target.isPosix()) {
-                    if (pthread_cond_wait(addr_of(deref(threadNativePtr).outbound_cond), addr_of(deref(threadNativePtr).mutex)).isNonZero()) abort();
-                }
-                oldVal = statusPtr.loadVolatile().intValue();
-            }
-            // the request is cleared; now, attempt to clear the safepoint state and notify waiters
-            int witness = statusPtr.compareAndSwap(word(oldVal), word(oldVal & ~STATE_IN_SAFEPOINT & ~clearBits | setBits)).intValue();
-            if (witness == oldVal) {
-                // success!
-                break;
-            }
-            // try again
-            oldVal = witness;
-        }
-        // done! notify waiters
-        if (Build.Target.isLinux()) {
-            futex_wake_all(statusPtr);
-        } else if (Build.Target.isWasi()) {
-            // TODO
-            //  memory.atomic.notify(statusPtr, Integer.MAX_VALUE)
-            abort();
-        } else if (Build.Target.isPosix()) {
-            if (pthread_cond_broadcast(addr_of(deref(threadNativePtr).outbound_cond)).isNonZero()) abort();
-            if (pthread_mutex_unlock(addr_of(deref(threadNativePtr).mutex)).isNonZero()) abort();
-        }
-        return oldVal;
-    }
-
-    // todo: move this to main?
-    @constructor
-    @export
-    private static void init_thread_list_mutex() {
-        // initialize the mutex at early run time
-        pthread_mutex_init(addr_of(thread_list_mutex), zero());
     }
 
     static final class CleanupAction implements Runnable {

--- a/java.base/src/main/java/java/lang/UnsafeParkUnpark.java
+++ b/java.base/src/main/java/java/lang/UnsafeParkUnpark.java
@@ -32,9 +32,8 @@
 
 package java.lang;
 
-import static java.lang.Thread.*;
-
 import jdk.internal.misc.Unsafe;
+import jdk.internal.thread.ThreadNative;
 import org.qbicc.rt.annotation.Tracking;
 import org.qbicc.runtime.patcher.PatchClass;
 import org.qbicc.runtime.patcher.Replace;
@@ -54,20 +53,20 @@ final class UnsafeParkUnpark {
             if (millis <= 0) {
                 return;
             }
-            Thread.park(millis, 0, STATE_PARKED | STATE_WAITING | STATE_WAITING_WITH_TIMEOUT, STATE_RUNNABLE, STATE_INTERRUPTED, STATE_UNPARK);
+            ThreadNative.park(millis, 0, ThreadNative.STATE_PARKED | ThreadNative.STATE_WAITING | ThreadNative.STATE_WAITING_WITH_TIMEOUT, ThreadNative.STATE_RUNNABLE, ThreadNative.STATE_INTERRUPTED, ThreadNative.STATE_UNPARK);
         } else if (time == 0) {
             // no timeout
-            Thread.park(0, 0, STATE_PARKED | STATE_WAITING | STATE_WAITING_INDEFINITELY, STATE_RUNNABLE, STATE_INTERRUPTED, STATE_UNPARK);
+            ThreadNative.park(0, 0, ThreadNative.STATE_PARKED | ThreadNative.STATE_WAITING | ThreadNative.STATE_WAITING_INDEFINITELY, ThreadNative.STATE_RUNNABLE, ThreadNative.STATE_INTERRUPTED, ThreadNative.STATE_UNPARK);
         } else {
             // relative timeout in nanos
             int nanos = (int) (time % 1_000_000);
             long millis = time / 1_000_000;
-            Thread.park(millis, nanos, STATE_PARKED | STATE_WAITING | STATE_WAITING_WITH_TIMEOUT, STATE_RUNNABLE, STATE_INTERRUPTED, STATE_UNPARK);
+            ThreadNative.park(millis, nanos, ThreadNative.STATE_PARKED | ThreadNative.STATE_WAITING | ThreadNative.STATE_WAITING_WITH_TIMEOUT, ThreadNative.STATE_RUNNABLE, ThreadNative.STATE_INTERRUPTED, ThreadNative.STATE_UNPARK);
         }
     }
 
     @Replace
     void unpark(Object thread) {
-        ((Thread) thread).unpark(STATE_UNPARK);
+        ((Thread) thread).unpark(ThreadNative.STATE_UNPARK);
     }
 }

--- a/java.base/src/main/java/jdk/internal/gc/ArrayAccess.java
+++ b/java.base/src/main/java/jdk/internal/gc/ArrayAccess.java
@@ -1,0 +1,8 @@
+package jdk.internal.gc;
+
+import org.qbicc.runtime.patcher.Patch;
+
+@Patch("[")
+final class ArrayAccess {
+    int length;
+}

--- a/java.base/src/main/java/jdk/internal/gc/ClassAccess.java
+++ b/java.base/src/main/java/jdk/internal/gc/ClassAccess.java
@@ -1,0 +1,16 @@
+package jdk.internal.gc;
+
+import static org.qbicc.runtime.CNative.*;
+import static org.qbicc.runtime.stdc.Stdint.*;
+
+import org.qbicc.runtime.patcher.PatchClass;
+
+@PatchClass(Class.class)
+final class ClassAccess {
+    long referenceBitMap;
+    int modifiers;
+    int instanceSize;
+    type_id id;
+    ClassAccess componentType;
+    uint8_t dimension;
+}

--- a/java.base/src/main/java/jdk/internal/gc/Gc.java
+++ b/java.base/src/main/java/jdk/internal/gc/Gc.java
@@ -1,0 +1,976 @@
+package jdk.internal.gc;
+
+import static jdk.internal.sys.linux.Futex.futex_wait_bits;
+import static jdk.internal.sys.posix.Errno.*;
+
+import static jdk.internal.sys.posix.PThread.*;
+import static jdk.internal.sys.posix.SysMman.*;
+import static jdk.internal.sys.posix.Unistd.*;
+import static jdk.internal.thread.ThreadNative.*;
+import static org.qbicc.runtime.CNative.*;
+import static org.qbicc.runtime.ExtModifier.*;
+import static org.qbicc.runtime.stackwalk.CallSiteTable.*;
+import static org.qbicc.runtime.stdc.Errno.*;
+import static org.qbicc.runtime.stdc.Stddef.*;
+import static org.qbicc.runtime.stdc.Stdint.*;
+import static org.qbicc.runtime.stdc.Stdio.*;
+import static org.qbicc.runtime.stdc.Stdlib.*;
+import static org.qbicc.runtime.stdc.String.*;
+import static org.qbicc.runtime.unwind.LibUnwind.*;
+
+import jdk.internal.thread.ThreadNative;
+import org.qbicc.runtime.AutoQueued;
+import org.qbicc.runtime.Build;
+import org.qbicc.runtime.Hidden;
+import org.qbicc.runtime.Inline;
+import org.qbicc.runtime.InlineCondition;
+import org.qbicc.runtime.NoSafePoint;
+import org.qbicc.runtime.NoThrow;
+import org.qbicc.runtime.gc.heap.Heap;
+import org.qbicc.runtime.main.CompilerIntrinsics;
+import org.qbicc.runtime.stackwalk.StackWalker;
+
+public final class Gc {
+    private Gc() {}
+
+    static final ptr<struct_gc> gc;
+    static long pageSize;
+
+    static {
+        // build time initialization
+        final String gcAlgorithmName = getGcAlgorithmName();
+        gc = switch (gcAlgorithmName) {
+            case "semi" -> addr_of(SemiSpaceGc.gc);
+            default -> throw new IllegalArgumentException("Unknown GC \"" + gcAlgorithmName + "\"");
+        };
+    }
+
+    static native String getGcAlgorithmName();
+
+    static final Thread gc_thread = new Thread(ThreadNative.getSystemThreadGroup(), "GC thread") {
+        public void start() {
+            if (Build.isHost()) {
+                throw new IllegalStateException();
+            }
+            super.start();
+        }
+
+        @NoSafePoint
+        public void run() {
+            // never exit safepoint
+            ptr<thread_native> threadNativePtr = currentThreadNativePtr();
+            enterSafePoint(threadNativePtr, 0, 0);
+            // now wait for a GC request
+            for (;;) {
+                // TODO: CAS status word atomically with await...?
+                // assert isSafePoint();
+                final ptr<uint32_t> statusPtr = addr_of(deref(threadNativePtr).state);
+                int state = statusPtr.loadVolatile().intValue();
+                while ((state & STATE_SAFEPOINT_REQUEST_GC) == 0) {
+                    if (Build.Target.isLinux()) {
+                        // use futex operations to await our desired bit pattern
+                        if (! futex_wait_bits(statusPtr, word(STATE_SAFEPOINT_REQUEST_GC), word(STATE_SAFEPOINT_REQUEST_GC), zero()) && errno != EINTR.intValue()) {
+                            // fatal error
+                            abort();
+                        }
+                    } else if (Build.Target.isWasi()) {
+                        // TODO
+                        //  memory.atomic.wait32(statusPtr, state & mask | bits, -1)
+                        abort();
+                    } else if (Build.Target.isPosix()) {
+                        // double-checked pattern, but using pthread_mutex
+                        int res = pthread_mutex_lock(addr_of(deref(threadNativePtr).mutex)).intValue();
+                        if (res != 0) {
+                            // fatal error
+                            abort();
+                        }
+                        state = statusPtr.loadVolatile().intValue();
+                        while ((state & STATE_SAFEPOINT_REQUEST_GC) != STATE_SAFEPOINT_REQUEST_GC) {
+                            res = pthread_cond_wait(addr_of(deref(threadNativePtr).inbound_cond), addr_of(deref(threadNativePtr).mutex)).intValue();
+                            if (res != 0) {
+                                // fatal error
+                                abort();
+                            }
+                            state = statusPtr.loadVolatile().intValue();
+                        }
+                        res = pthread_mutex_unlock(addr_of(deref(threadNativePtr).mutex)).intValue();
+                        if (res != 0) {
+                            // fatal error
+                            abort();
+                        }
+                        // done by interior loop
+                        break;
+                    }
+                    state = statusPtr.loadVolatile().intValue();
+                }
+                addr_of(deref(threadNativePtr).state).getAndBitwiseAnd(word(~STATE_SAFEPOINT_REQUEST_GC));
+                // a GC was requested; carry it out
+                pthread_mutex_lock(addr_of(thread_list_mutex));
+                // request safepoints of all threads
+                for (ptr<thread_native> current = thread_list_terminus.next; current != addr_of(thread_list_terminus); current = deref(current).next) {
+                    requestSafePoint(current, STATE_SAFEPOINT_REQUEST_GC);
+                    current = deref(current).next;
+                }
+                // await safepoints of all threads
+                for (ptr<thread_native> current = thread_list_terminus.next; current != addr_of(thread_list_terminus); current = deref(current).next) {
+                    awaitSafePoint(current);
+                    current = deref(current).next;
+                }
+                // now we are paused and free to manipulate the heap
+
+                deref(deref(gc).collect).asInvokable().run();
+
+                // release safepoint of all threads
+                for (ptr<thread_native> current = thread_list_terminus.next; current != addr_of(thread_list_terminus); current = deref(current).next) {
+                    releaseSafePoint(current, STATE_SAFEPOINT_REQUEST_GC);
+                    current = deref(current).next;
+                }
+
+                // todo: reference queues
+            }
+
+        }
+    };
+
+    @NoThrow
+    @NoSafePoint
+    public static long getPageSize() {
+        return pageSize;
+    }
+
+    public static void start() {
+        gc_thread.start();
+    }
+
+    /**
+     * A garbage collector definition.
+     */
+    @internal
+    public static final class struct_gc extends struct {
+        /**
+         * A pointer to the name of the GC implementation.
+         */
+        public ptr<@c_const c_char> name;
+        /**
+         * A pointer to a function which initializes the image heap.
+         */
+        public ptr<function<Initializer>> initialize_heap;
+        /**
+         * A pointer to a function which performs a collection when a GC is requested.
+         * This function is called under a safepoint from the GC thread.
+         */
+        public ptr<function<Runnable>> collect;
+        /**
+         * A pointer to a function which performs an allocation.
+         * The allocated memory must be zeroed.
+         */
+        public ptr<function<Allocator>> allocate;
+    }
+
+    /**
+     * Attributes which must be configured by the garbage collector.
+     */
+    @internal
+    public static final class struct_gc_attr extends struct {
+        /**
+         * The lowest address of any allocatable object on the heap.
+         */
+        public ptr<c_char> lowest_heap_addr;
+        /**
+         * The highest address of any allocatable object on the heap.
+         */
+        public ptr<c_char> highest_heap_addr;
+    }
+
+    @FunctionalInterface
+    public interface Initializer {
+        void initialize(ptr<struct_gc_attr> attr_ptr);
+    }
+
+    @FunctionalInterface
+    public interface Allocator {
+        reference<?> allocate(long size);
+    }
+
+    /**
+     * The special region for the root class set.
+     * These objects are not copied.
+     */
+    static struct_region classes;
+    /**
+     * The special region for the initial heap object set.
+     * The handling and placement of this region is dependent on the GC algorithm, which may copy its contents to other
+     * regions or use it in place.
+     */
+    static struct_region initial;
+    static struct_region strings;
+
+    /**
+     * The global marking bitmap.
+     */
+    static ptr<uintptr_t> bitmap;
+    /**
+     * The number of words in the global marking bitmap.
+     */
+    static size_t bitmapSize;
+
+    /**
+     * The lowest address of any object.
+     */
+    static ptr<uint8_t> heapBase;
+
+    /**
+     * The allocate method.
+     * This method is used to implement {@code new} and other related operations.
+     *
+     * @param size the allocation size
+     * @return a reference to the allocated memory
+     */
+    @Hidden
+    @AutoQueued
+    @NoSafePoint
+    public static Object allocate(long size) {
+        reference<?> allocated = deref(deref(gc).allocate).asInvokable().allocate(size);
+        if (allocated == null) {
+            // GC failure
+            abort();
+        }
+        return allocated;
+    }
+
+    @Hidden
+    @AutoQueued
+    @NoSafePoint
+    public static void clear(Object ptr, long size) {
+        memset(refToPtr(ptr), word(0), word(size));
+    }
+
+    @Hidden
+    @AutoQueued
+    @NoSafePoint
+    public static void copy(Object to, Object from, long size) {
+        memcpy(refToPtr(to), refToPtr(from), word(size));
+    }
+
+    @export
+    public static long getBitmapOffset(reference<?> ref) {
+        if (ref == null) abort();
+        ptr<uint8_t> refBytePtr = refToPtr(ref).cast();
+        long byteOffset = refBytePtr.minus(heapBase).longValue();
+        // the remaining computations are expected to be flattened to a single shift
+        // each bit represents N bytes where N is the minimum object alignment
+        int align = Heap.getConfiguredObjectAlignment();
+        // there could be 32 or 64 bits per word
+        int bitsPerWord = sizeof(uintptr_t.class).intValue() << 3;
+        long shift = Integer.numberOfTrailingZeros(align) + Integer.numberOfTrailingZeros(bitsPerWord);
+        // divide
+        return byteOffset >>> shift;
+    }
+
+    @export
+    public static uintptr_t getBitmapBit(reference<?> ref) {
+        if (ref == null) abort();
+        ptr<uint8_t> refBytePtr = refToPtr(ref).cast();
+        long byteOffset = refBytePtr.minus(heapBase).longValue();
+        int align = Heap.getConfiguredObjectAlignment();
+        long shift = Integer.numberOfTrailingZeros(align);
+        int bitsPerWord = sizeof(uintptr_t.class).intValue() << 3;
+        return word(1L << (byteOffset >> shift & bitsPerWord - 1));
+    }
+
+    @NoSafePoint
+    @NoThrow
+    @Hidden
+    public static void clearBitmap() {
+        if (Build.Target.isPosix()) {
+            ptr<?> res = mmap(bitmap, bitmapSize, word(PROT_READ.intValue() | PROT_WRITE.intValue()), word(MAP_FIXED.intValue() | MAP_PRIVATE.intValue() | MAP_ANON.intValue()), word(- 1), zero());
+            if (res == MAP_FAILED) {
+                // should generally be impossible, because we have the memory already
+                abort();
+            }
+        }
+    }
+
+    // intrinsics which help with setting up the initial regions and memory areas.
+
+    static native ptr<?> getClassRegionStart();
+    static native long getClassRegionSize();
+    static native ptr<?> getInitialHeapRegionStart();
+    static native long getInitialHeapRegionSize();
+    static native ptr<?> getInitialHeapStringsRegionStart();
+    static native long getInitialHeapStringsRegionSize();
+
+    static native ptr<reference<?>> getReferenceTypedVariablesStart();
+    static native int getReferenceTypedVariablesCount();
+
+    /**
+     * Initialize the heap at program start.
+     */
+    @export
+    public static void qbicc_initialize_heap() {
+        if (Build.Target.isPosix()) {
+            int pageSize = sysconf(_SC_PAGE_SIZE).intValue();
+            if (pageSize == -1) {
+                abort();
+            }
+            if (Integer.bitCount(pageSize) != 1) {
+                // not a power of 2? but not likely enough to be worth spending memory on an error message
+                abort();
+            }
+            Gc.pageSize = pageSize;
+        } else {
+            abort();
+        }
+
+        struct_gc_attr gc_attr = auto(zero());
+
+        // initialize our built-in heap regions
+        classes.start = getClassRegionStart();
+        classes.limit = classes.position = getClassRegionSize();
+
+        initial.start = getInitialHeapRegionStart();
+        initial.limit = initial.position = getInitialHeapRegionSize();
+
+        strings.start = getInitialHeapStringsRegionStart();
+        strings.limit = strings.position = getInitialHeapStringsRegionSize();
+
+        // now, call GC-specific heap init routine
+        deref(deref(gc).initialize_heap).asInvokable().initialize(addr_of(gc_attr));
+
+        // find the lowest possible heap address
+        ptr<c_char> lowest = gc_attr.lowest_heap_addr;
+        if (classes.start.isLt(lowest)) {
+            lowest = classes.start.cast();
+        }
+        if (initial.start.isLt(lowest)) {
+            lowest = initial.start.cast();
+        }
+        if (strings.start.isLt(lowest)) {
+            lowest = strings.start.cast();
+        }
+        heapBase = lowest.cast();
+        // find the highest possible heap address
+        ptr<c_char> highest = gc_attr.highest_heap_addr;
+        if (classes.start.plus(classes.limit).isGt(highest)) {
+            highest = classes.start.plus(classes.limit).cast();
+        }
+        if (initial.start.plus(initial.limit).isGt(highest)) {
+            highest = initial.start.plus(initial.limit).cast();
+        }
+        if (strings.start.plus(strings.limit).isGt(highest)) {
+            highest = strings.start.plus(strings.limit).cast();
+        }
+        bitmapSize = word(highest.minus(lowest).longValue() / 8);
+
+        // this mapping could be fairly large; but, we only use pages corresponding to places where objects may reside
+        bitmap = mmap(zero(), bitmapSize, word(PROT_READ.intValue() | PROT_WRITE.intValue()), word(MAP_PRIVATE.intValue() | MAP_ANON.intValue()), word(- 1), zero());
+        if (bitmap == MAP_FAILED) {
+            // not able to allocate memory
+            // todo: set errno, fail gracefully...
+            abort();
+        }
+    }
+
+    /**
+     * Initialize an iterator for walking the reference values reachable from the given object.
+     *
+     * @param iter the iterator pointer, which typically should be stack-allocated (must not be {@code null})
+     * @param obj the object reference to iterate
+     */
+    @NoSafePoint
+    @NoThrow
+    @Hidden
+    @export(withScope = ExportScope.LOCAL)
+    public static void clv_iterator_init(ptr<clv_iterator> iter, Object obj) {
+        if (obj == null) {
+            deref(iter).base = zero();
+            deref(iter).state = 0;
+            deref(iter).next = zero();
+        } else {
+            deref(iter).base = refToPtr(obj).cast();
+            // determine if the class has an extended bitmap
+            ClassAccess ca = cast(CompilerIntrinsics.getClassFromTypeIdSimple(((ObjectAccess)obj).typeId));
+            if ((ca.modifiers & I_ACC_EXTENDED_BITMAP) != 0) {
+                // extended bitmap!
+                ptr<uint64_t> bmp = word(ca.referenceBitMap);
+                deref(iter).state = bmp.loadUnshared().longValue();
+                deref(iter).next = bmp.plus(1);
+            } else {
+                // normal bitmap!
+                deref(iter).state = ca.referenceBitMap;
+                deref(iter).next = zero();
+            }
+        }
+    }
+
+    /**
+     * Iterate to the next reference which is contained by the object referenced in the iterator (if any).
+     *
+     * @param iter the iterator pointer, which typically should be stack-allocated (must not be {@code null})
+     * @return the next reference, or {@code null} if there are no more references reachable from this object
+     */
+    @NoSafePoint
+    @NoThrow
+    @Hidden
+    @export(withScope = ExportScope.LOCAL)
+    public static reference<?> clv_iterator_next(ptr<clv_iterator> iter) {
+        long bits = deref(iter).state;
+        do {
+            while (bits != 0) {
+                final long lob = Long.lowestOneBit(bits);
+                bits &= ~lob;
+                int offset = Long.numberOfTrailingZeros(lob);
+                final ptr<reference<?>> refLoc = deref(iter).base.plus(offset);
+                reference<?> ref = refLoc.loadUnshared();
+                if (ref != null) {
+                    deref(iter).state = bits;
+                    deref(iter).current = refLoc;
+                    return ref;
+                }
+            }
+            ptr<uint64_t> next = deref(iter).next;
+            if (next.isNonNull()) {
+                bits = next.loadUnshared().longValue();
+                if (bits != 0) {
+                    deref(iter).next = next.plus(1);
+                }
+            }
+        } while (bits != 0);
+        // done
+        deref(iter).state = 0;
+        deref(iter).next = zero();
+        deref(iter).current = zero();
+        return null;
+    }
+
+    /**
+     * Change the value of the reference location corresponding to the reference most recently returned by
+     * {@link #clv_iterator_next(ptr)}.
+     *
+     * @param iter the iterator pointer, which typically should be stack-allocated (must not be {@code null})
+     * @param newVal the updated reference value
+     */
+    @NoSafePoint
+    @NoThrow
+    @Hidden
+    @export(withScope = ExportScope.LOCAL)
+    public static void clv_iterator_set(ptr<clv_iterator> iter, reference<?> newVal) {
+        deref(iter).current.storePlain(newVal);
+    }
+
+    /**
+     * Implementation-specific operation to mark an object.
+     *
+     * @param ref the reference to the object to mark (must not be {@code null})
+     * @return {@code true} if the ref was newly marked as a result of this operation, or {@code false}
+     *      if it was already marked or is permanent
+     */
+    @NoSafePoint
+    @NoThrow
+    @Hidden
+    static boolean setMark(reference<?> ref) {
+        long off = getBitmapOffset(ref);
+        uintptr_t bitVal = getBitmapBit(ref);
+        uintptr_t observed = bitmap.plus(off).getAndBitwiseOrOpaque(bitVal);
+        return (observed.longValue() & bitVal.longValue()) == 0;
+    }
+
+    @NoSafePoint
+    @NoThrow
+    @Hidden
+    static boolean isMarked(reference<?> ref) {
+        long off = getBitmapOffset(ref);
+        uintptr_t bitVal = getBitmapBit(ref);
+        uintptr_t observed = bitmap.plus(off).loadOpaque();
+        return (observed.longValue() & bitVal.longValue()) != 0;
+    }
+
+    @NoSafePoint
+    @NoThrow
+    @Hidden
+    static void setHeaderMovedBit(reference<?> ref) {
+        final ptr<header_type> headerPtr = addr_of(deref(refToPtr((ObjectAccess)ref.toObject())).header);
+        headerPtr.getAndBitwiseOrOpaque(headerMovedBit());
+    }
+
+    @NoSafePoint
+    @NoThrow
+    @Hidden
+    static boolean getHeaderMovedBit(reference<?> ref) {
+        final ptr<header_type> headerPtr = addr_of(deref(refToPtr((ObjectAccess)ref.toObject())).header);
+        return (headerPtr.loadUnshared().longValue() & headerMovedBit().longValue()) != 0;
+    }
+
+    /**
+     * Intrinsic which returns the header "object moved" bit as the sole set bit of the returned word.
+     * If the header has no such bit, then the returned value is a zero constant.
+     *
+     * @return the "object moved" bit, or zero if there is no "object moved" bit
+     */
+    @NoSafePoint
+    @NoThrow
+    static native header_type headerMovedBit();
+
+    /**
+     * Intrinsic which returns the header "stack allocated" bit as the sole set bit of the returned word.
+     * If the header has no such bit, then the returned value is a zero constant.
+     *
+     * @return the "stack allocated" bit, or zero if there is no "stack allocated" bit
+     */
+    @NoSafePoint
+    @NoThrow
+    static native header_type headerStackAllocatedBit();
+
+    @NoSafePoint
+    @NoThrow
+    @Hidden
+    static boolean isStackAllocated(reference<?> ref) {
+        final ptr<header_type> headerPtr = addr_of(deref(refToPtr((ObjectAccess)ref.toObject())).header);
+        return (headerPtr.loadUnshared().longValue() & headerStackAllocatedBit().longValue()) != 0;
+    }
+
+    /**
+     * A basic recursive mark routine for objects.
+     *
+     * @param object the object to mark (must not be {@code null})
+     */
+    @NoSafePoint
+    @NoThrow
+    @export
+    static void mark(Object object) {
+        if (! setMark(reference.of(object))) {
+            return;
+        }
+        markBasic0(reference.of(object));
+    }
+
+    /**
+     * Mark all the objects which are currently reachable by the stack of this thread.
+     */
+    @NoSafePoint
+    @NoThrow
+    @export
+    static void markCurrentStack() {
+        StackWalker sw = new StackWalker();
+        lvi_iterator lviIter = auto();
+        unw_cursor_t cursor = auto();
+        ptr<struct_call_site> call_site_ptr;
+        reference<?> ref;
+        while (sw.next()) {
+            call_site_ptr = sw.getCallSite();
+            if (call_site_ptr != null) {
+                lvi_iterator_init(addr_of(lviIter), call_site_ptr);
+                sw.getCursor(addr_of(cursor));
+                while ((ref = lvi_iterator_next(addr_of(lviIter), addr_of(cursor))) != null) {
+                    if (setMark(ref)) {
+                        markBasic0(ref);
+                    }
+                }
+            }
+        }
+    }
+
+    /**
+     * Mark all the objects which are currently reachable by the stack of the given safepointed thread.
+     *
+     * @param threadNativePtr the safepointed thread native pointer (must not be {@code null})
+     */
+    @NoSafePoint
+    @NoThrow
+    @export
+    static void markStack(ptr<thread_native> threadNativePtr) {
+        StackWalker sw = new StackWalker(addr_of(deref(threadNativePtr).saved_context));
+        lvi_iterator lviIter = auto();
+        unw_cursor_t cursor = auto();
+        ptr<struct_call_site> call_site_ptr;
+        reference<?> ref;
+        while (sw.next()) {
+            call_site_ptr = sw.getCallSite();
+            if (call_site_ptr != null) {
+                lvi_iterator_init(addr_of(lviIter), call_site_ptr);
+                sw.getCursor(addr_of(cursor));
+                while ((ref = lvi_iterator_next(addr_of(lviIter), addr_of(cursor))) != null) {
+                    if (setMark(ref)) {
+                        markBasic0(ref);
+                    }
+                }
+            }
+        }
+    }
+
+    /**
+     * Mark all the allocates objects within the given region.
+     *
+     * @param regionPtr the region pointer (must not be {@code null})
+     */
+    @NoSafePoint
+    @NoThrow
+    static void markRegion(ptr<struct_region> regionPtr) {
+        struct_region_iter iter = auto();
+        region_iter_init(addr_of(iter), regionPtr);
+        for (ptr<?> next = region_iter_next(addr_of(iter)); next != null; next = region_iter_next(addr_of(iter))) {
+            mark(ptrToRef(next));
+        }
+    }
+
+    @NoSafePoint
+    @NoThrow
+    @export
+    private static void markBasic0(final reference<?> ref) {
+        clv_iterator iter = auto();
+        clv_iterator_init(addr_of(iter), ref.toObject());
+        reference<?> cur = clv_iterator_next(addr_of(iter));
+        reference<?> next;
+        while (cur != null) {
+            next = clv_iterator_next(addr_of(iter));
+            if (setMark(cur)) {
+                if (next == null) {
+                    // we have nothing else to mark, so mark `cur` now
+                    clv_iterator_init(addr_of(iter), cur.toObject());
+                    next = clv_iterator_next(addr_of(iter));
+                } else {
+                    markBasic0(cur);
+                }
+            }
+            cur = next;
+        }
+        // special case: arrays
+        // todo: eventually generalize this using a second bitmap, to support future arrays of user primitive types
+        if (ref.toObject() instanceof Object[] arr) {
+            for (Object o : arr) {
+                if (o != null && setMark(reference.of(o))) {
+                    markBasic0(reference.of(o));
+                }
+            }
+        }
+    }
+
+    /**
+     * An iterator for a class live value bitmap.
+     */
+    @internal
+    public static final class clv_iterator extends struct {
+        ptr<reference<?>> base;
+        long state;
+        ptr<uint64_t> next;
+        ptr<reference<?>> current;
+    }
+
+    /**
+     * A linear region of memory that can be allocated from.
+     */
+    @internal
+    public static final class struct_region extends struct {
+        /**
+         * The start of the memory region.
+         */
+        public ptr<?> start;
+        /**
+         * The position of the next allocation (aligned to object alignment).
+         * The unit is bytes. TODO: maybe make it object-alignment increments instead?
+         */
+        public long position;
+        /**
+         * The size of this memory region; the region is full when {@code position == limit}.
+         * The unit is bytes. TODO: maybe make it object-alignment increments instead?
+         */
+        public long limit;
+    }
+
+    /**
+     * Determine whether the given pointer falls within the given region.
+     *
+     * @param region_ptr the region pointer (must not be {@code null})
+     * @param ptr the pointer to test
+     * @return {@code true} if the pointer falls within the region, or {@code false} if it does not
+     */
+    @NoSafePoint
+    @NoThrow
+    @export
+    public static boolean region_contains(ptr<struct_region> region_ptr, ptr<?> ptr) {
+        final long diff = ptr.minus(deref(region_ptr).start.cast()).longValue();
+        return diff >= 0 && diff < deref(region_ptr).limit;
+    }
+
+    /**
+     * Establish a heap region at the given pre-allocated start address.
+     *
+     * @param region_ptr the region pointer (must not be {@code null})
+     * @param start the region start
+     * @param limit the region size
+     * @return {@code true} if the region was established, or {@code false} if there was an error
+     * ({@code errno} will be set accordingly)
+     */
+    @NoSafePoint
+    @NoThrow
+    @export
+    public static boolean region_init(ptr<struct_region> region_ptr, ptr<?> start, long limit) {
+        if (limit == 0 || (limit & Gc.getPageSize() - 1) != 0 || region_ptr.isNull() || start.isNull()) {
+            errno = EINVAL.intValue();
+            return false;
+        }
+        // clear the structure
+        region_ptr.storeUnshared(zero());
+        // establish the start and limit
+        deref(region_ptr).start = start;
+        deref(region_ptr).limit = limit;
+        return true;
+    }
+
+    /**
+     * Allocate from this region if possible.
+     *
+     * @param region_ptr the region to allocate from (must not be {@code null})
+     * @param size the number of bytes to allocate
+     * @return a pointer to the allocated item, or {@code null} if allocation did not succeed
+     */
+    @NoSafePoint
+    @NoThrow
+    @export
+    public static <P extends ptr<?>> P region_allocate(ptr<struct_region> region_ptr, long size) {
+        final long limit = deref(region_ptr).limit;
+        // round up the size so the next allocation is aligned
+        final int mask = Heap.getConfiguredObjectAlignment() - 1;
+        size = (size + mask) & ~mask;
+        if (size > limit) {
+            // fail fast; it can never fit
+            return null;
+        }
+        ptr<int64_t> position_ptr = addr_of(deref(region_ptr).position);
+        long oldVal, newVal;
+        long witness;
+        oldVal = position_ptr.loadSingleAcquire().longValue();
+        for (;;) {
+            newVal = oldVal + size;
+            if (newVal > limit) {
+                return null;
+            }
+            witness = position_ptr.compareAndSwapRelease(word(oldVal), word(newVal)).longValue();
+            if (oldVal == witness) {
+                // success; return the pointer
+                return deref(region_ptr).start.plus(oldVal).cast();
+            }
+            oldVal = witness;
+        }
+    }
+
+    /**
+     * Reset the region so that it can be allocated from again (typically after it is cleared by garbage collection).
+     *
+     * @param region_ptr the region pointer (must not be {@code null})
+     */
+    @NoSafePoint
+    @NoThrow
+    @export
+    public static void region_reset(ptr<struct_region> region_ptr) {
+        addr_of(deref(region_ptr).position).storeRelease(zero());
+    }
+
+    /**
+     * An object iterator for a region.
+     */
+    @internal
+    public static final class struct_region_iter extends struct {
+        public ptr<struct_region> region_ptr;
+        public long current_size;
+        public long position;
+    }
+
+    /**
+     * The structure of a relocated object.
+     */
+    @internal
+    public static final class struct_relocated extends struct {
+        public header_type header;
+        public reference<?> relocation;
+    }
+
+    /**
+     * Initialize an object iterator for a region.
+     *
+     * @param iter_ptr the iterator pointer, typically stack-allocated (must not be {@code null})
+     * @param region_ptr the region pointer (must not be {@code null})
+     */
+    @export
+    public static void region_iter_init(ptr<struct_region_iter> iter_ptr, ptr<struct_region> region_ptr) {
+        deref(iter_ptr).region_ptr = region_ptr;
+        deref(iter_ptr).position = 0;
+    }
+
+    /**
+     * Get a pointer to the next object in the region.
+     *
+     * @param iter_ptr the iterator pointer, typically stack-allocated (must not be {@code null})
+     * @return the pointer to the next object in the region, or {@code null} if there are no more objects in the region
+     * @param <P> the pointer type to return
+     */
+    @export
+    public static <P extends ptr<?>> P region_iter_next(ptr<struct_region_iter> iter_ptr) {
+        final long endOfObjects = deref(deref(iter_ptr).region_ptr).position;
+        if (deref(iter_ptr).position >= endOfObjects) {
+            return null;
+        }
+        // save the pointer
+        ptr<?> next = deref(deref(iter_ptr).region_ptr).start.plus(deref(iter_ptr).position);
+        long size = deref(iter_ptr).current_size = instance_size(ptrToRef(next));
+        final int mask = Heap.getConfiguredObjectAlignment() - 1;
+        size = (size + mask) & ~mask;
+        deref(iter_ptr).position += size;
+        return next.cast();
+    }
+
+    /**
+     * Get the size of the last object returned by {@link #region_iter_next(ptr)}.
+     *
+     * @param iter_ptr the iterator pointer (must not be {@code null})
+     * @return the size of the last object returned
+     */
+    @NoSafePoint
+    @NoThrow
+    @export
+    @Inline(InlineCondition.ALWAYS)
+    public static long region_iter_size(ptr<struct_region_iter> iter_ptr) {
+        return deref(iter_ptr).current_size;
+    }
+
+    /**
+     * Get the size in bytes of the object, not including trailing padding required for alignment.
+     *
+     * @param obj the object to test (must not be {@code null})
+     * @return the size in bytes
+     */
+    @NoSafePoint
+    @NoThrow
+    @export
+    public static long instance_size(Object obj) {
+        ObjectAccess oa = cast(obj);
+        type_id baseId = oa.typeId;
+        ClassAccess ca = cast(CompilerIntrinsics.getClassFromTypeIdSimple(baseId));
+        long baseSize = ca.instanceSize;
+        // todo: use a modifier flag to identify arrays
+        long elemSize;
+        if (CompilerIntrinsics.isPrimArray(baseId)) {
+            // get element size
+            ClassAccess ct = ca.componentType;
+            elemSize = ct.instanceSize;
+        } else if (CompilerIntrinsics.isReferenceArray(baseId)) {
+            elemSize = sizeof(reference.class).longValue();
+        } else {
+            // done
+            return baseSize;
+        }
+        // get array length
+        ArrayAccess aa = cast(obj);
+        int length = aa.length;
+        return baseSize + length * elemSize;
+    }
+
+    /**
+     * Move an object to the destination region and set the relocation pointer on the original object.
+     *
+     * @param original the original object reference (must not be {@code null})
+     * @param destination the region to move the object to (must not be {@code null}, must have sufficient space)
+     */
+    @NoSafePoint
+    @NoThrow
+    @export
+    public static void move_object(reference<?> original, ptr<struct_region> destination) {
+        final ptr<Object> oldPtr = refToPtr(original.toObject());
+        // we must move it; allocate space for the new object
+        final long size = instance_size(original.toObject());
+        // todo: allocate extra size for lock, hashCode, etc. if needed, resulting in newSize
+        // todo: inflating objects could theoretically cause the "to" space to be bigger than the "from" space!
+        final ptr<?> newPtr = region_allocate(destination, /*newSize*/size);
+        if (newPtr == null) {
+            // no free space is a fatal error! there is nothing else we can do
+            fprintf(stderr, utf8z("Failed to allocate during GC move\n"));
+            abort();
+        }
+        // move the object to its new home
+        // todo: update header bits as needed for new information like lock, hashCode
+        memcpy(newPtr, oldPtr, word(/*newSize*/size));
+        // set the moved-to location
+        setHeaderMovedBit(original);
+        deref(oldPtr, struct_relocated.class).relocation = reference.of(ptrToRef(newPtr));
+    }
+
+    /**
+     * Update a single reference if the target has been relocated.
+     */
+    @NoSafePoint
+    @NoThrow
+    @export
+    public static void update_reference(ptr<reference<?>> ref_ptr) {
+        reference<?> ref = ref_ptr.loadPlain();
+        if (ref != null && getHeaderMovedBit(ref)) {
+            ref_ptr.storePlain(deref(refToPtr(ref.toObject()), struct_relocated.class).relocation);
+        }
+    }
+
+    /**
+     * Update all the reference-typed fields of all the objects within a region with relocated references
+     * if their target object has been relocated.
+     */
+    @NoSafePoint
+    @NoThrow
+    @export
+    public static void update_region(ptr<struct_region> region_ptr) {
+        clv_iterator iter = auto();
+        struct_region_iter region_iter = auto();
+        region_iter_init(addr_of(region_iter), region_ptr);
+        ptr<?> objPtr;
+        while ((objPtr = region_iter_next(addr_of(region_iter))) != null) {
+            clv_iterator_init(addr_of(iter), ptrToRef(objPtr));
+            reference<?> ref;
+            while ((ref = clv_iterator_next(addr_of(iter))) != null) {
+                if (getHeaderMovedBit(ref)) {
+                    clv_iterator_set(addr_of(iter), deref(refToPtr(ref.toObject()), struct_relocated.class).relocation);
+                }
+            }
+        }
+    }
+
+    /**
+     * Update all the reference-typed fields of all the objects on this thread's stack with relocated references
+     * if their target object has been relocated.
+     */
+    @NoSafePoint
+    @NoThrow
+    public static void update_stack(ptr<thread_native> threadNativePtr) {
+        StackWalker sw = new StackWalker(addr_of(deref(threadNativePtr).saved_context));
+        lvi_iterator lvi_iter = auto();
+        unw_cursor_t cursor = auto();
+        ptr<struct_call_site> call_site_ptr;
+        reference<?> ref;
+        while (sw.next()) {
+            call_site_ptr = sw.getCallSite();
+            if (call_site_ptr != null) {
+                lvi_iterator_init(addr_of(lvi_iter), call_site_ptr);
+                sw.getCursor(addr_of(cursor));
+                while ((ref = lvi_iterator_next(addr_of(lvi_iter), addr_of(cursor))) != null) {
+                    if (getHeaderMovedBit(ref)) {
+                        lvi_iterator_set(addr_of(lvi_iter), addr_of(cursor), deref(refToPtr(ref.toObject()), struct_relocated.class).relocation);
+                    } else if (isStackAllocated(ref)) {
+                        update_stack_allocated(ref);
+                    }
+                }
+            }
+        }
+    }
+
+    @NoSafePoint
+    @NoThrow
+    private static void update_stack_allocated(reference<?> ref) {
+        clv_iterator clv_iter = auto();
+        // iterate the fields of the object and update them
+        clv_iterator_init(addr_of(clv_iter), ref);
+        while ((ref = clv_iterator_next(addr_of(clv_iter))) != null) {
+            if (getHeaderMovedBit(ref)) {
+                clv_iterator_set(addr_of(clv_iter), deref(refToPtr(ref.toObject()), struct_relocated.class).relocation);
+            } else if (isStackAllocated(ref)) {
+                // TODO: cyclic refs are a problem; visited bit
+                update_stack_allocated(ref);
+            }
+        }
+    }
+}

--- a/java.base/src/main/java/jdk/internal/gc/ObjectAccess.java
+++ b/java.base/src/main/java/jdk/internal/gc/ObjectAccess.java
@@ -1,0 +1,11 @@
+package jdk.internal.gc;
+
+import static org.qbicc.runtime.CNative.*;
+
+import org.qbicc.runtime.patcher.PatchClass;
+
+@PatchClass(Object.class)
+final class ObjectAccess {
+    header_type header;
+    type_id typeId;
+}

--- a/java.base/src/main/java/jdk/internal/gc/SemiSpaceGc.java
+++ b/java.base/src/main/java/jdk/internal/gc/SemiSpaceGc.java
@@ -1,0 +1,182 @@
+package jdk.internal.gc;
+
+import static jdk.internal.gc.Gc.*;
+import static jdk.internal.sys.posix.SysMman.*;
+import static jdk.internal.thread.ThreadNative.*;
+
+import static org.qbicc.runtime.CNative.*;
+import static org.qbicc.runtime.stdc.Stdlib.*;
+
+import org.qbicc.runtime.Build;
+import org.qbicc.runtime.NoSafePoint;
+import org.qbicc.runtime.NoThrow;
+import org.qbicc.runtime.gc.heap.Heap;
+
+/**
+ * A basic garbage collector which moves live objects between two equally-sized spaces.
+ */
+public final class SemiSpaceGc {
+
+    @export(withScope = ExportScope.LOCAL)
+    private static void collect() {
+        // mark threads and thread stacks
+        for (ptr<thread_native> current = thread_list_terminus.next; current != addr_of(thread_list_terminus); current = deref(current).next) {
+            //todo: we could come up with a way for each thread to mark its own stack before entering safepoint
+            //todo: threads must release their TLABs
+            markStack(current);
+            mark(deref(current).ref);
+        }
+
+        // mark all permanent objects
+        markRegion(addr_of(classes));
+        // todo: these will eventually be on the regular heap
+        markRegion(addr_of(strings));
+        markRegion(addr_of(initial));
+
+        // mark all refs
+        for (int i = 0; i < getReferenceTypedVariablesCount(); i ++) {
+            Object obj = getReferenceTypedVariablesStart().plus(i).loadPlain();
+            if (obj != null) {
+                mark(obj);
+            }
+        }
+
+        // move live objects to _to_ space
+        relocate_objects();
+
+        // update all objects in _to_ space
+        update_region(addr_of(to));
+
+        // swap spaces
+        swap();
+
+        // update all permanent objects
+        update_region(addr_of(classes));
+     // update_region(addr_of(strings)); // this region only contains interior pointers!
+        update_region(addr_of(initial));
+
+        for (int i = 0; i < getReferenceTypedVariablesCount(); i ++) {
+            update_reference(getReferenceTypedVariablesStart().plus(i));
+        }
+
+        // update threads and thread stacks
+        for (ptr<thread_native> current = thread_list_terminus.next; current != addr_of(thread_list_terminus); current = deref(current).next) {
+            //todo: we could come up with a way for each thread to update its own stack before leaving safepoint
+            update_reference(addr_of(deref(current).ref));
+            update_stack(current);
+        }
+
+        clearBitmap();
+    }
+
+    static {
+        gc_thread.setDaemon(true);
+    }
+
+    /**
+     * The space where objects are being allocated to.
+     */
+    private static struct_region from;
+    /**
+     * The space where objects will move to during GC.
+     */
+    private static struct_region to;
+
+    public static final struct_gc gc = zero();
+
+    static {
+        // set up the structure during build time
+        gc.name = utf8z("semi");
+        gc.initialize_heap = addr_of(function.of(SemiSpaceGc::initialize_heap));
+        gc.collect = addr_of(function.of(SemiSpaceGc::collect));
+        gc.allocate = addr_of(function.of(SemiSpaceGc::allocate));
+    }
+
+    @export
+    private static void initialize_heap(ptr<struct_gc_attr> attr_ptr) {
+        // todo: clean this part up
+        ptr<?> start;
+        long heapSize = Heap.getConfiguredMaxHeapSize();
+        // we need to round heap size down to a page * 2 boundary
+        long pageSize = Gc.getPageSize();
+        heapSize &= ~((pageSize << 1) - 1);
+        if (! Build.Target.isWasm()) {
+            start = mmap(zero(), word(heapSize), word(PROT_READ.longValue() | PROT_WRITE.longValue()), word(MAP_PRIVATE.longValue() | MAP_ANON.longValue()), word(-1), zero()).cast();
+        } else {
+            // TODO: WASI load region
+            start = zero();
+        }
+        if (start == MAP_FAILED) {
+            // todo: fail gracefully (errno)
+            abort();
+        }
+        deref(attr_ptr).lowest_heap_addr = start.cast();
+        deref(attr_ptr).highest_heap_addr = start.plus(heapSize).cast();
+        // since heapSize is a page * 2 boundary, semiSize is on a page boundary
+        long semiSize = heapSize >>> 1;
+        if (! region_init(addr_of(from), start, semiSize) || ! region_init(addr_of(to), start.plus(semiSize), semiSize)) {
+            // heap failure
+            abort();
+        }
+        // other regions are initialized by common code
+    }
+
+    @NoSafePoint
+    @NoThrow
+    private static void swap() {
+        // todo: swap(addr_of(from), addr_of(to))
+        @SuppressWarnings("UnusedAssignment")
+        struct_region tmp = auto();
+        tmp = to;
+        to = from;
+        from = tmp;
+        region_reset(addr_of(to));
+        if (! Build.Target.isWasm()) {
+            // give memory back to OS while clearing
+            final ptr<?> res = mmap(to.start.cast(), word(to.limit), word(PROT_READ.longValue() | PROT_WRITE.longValue()), word(MAP_FIXED.longValue() | MAP_PRIVATE.longValue() | MAP_ANON.longValue()), zero(), zero());
+            if (res == MAP_FAILED || res != to.start) {
+                abort();
+            }
+        }
+    }
+
+    @export
+    private static reference<?> allocate(long size) {
+        ptr<?> ptr = region_allocate(addr_of(from), size);
+        if (ptr == null) {
+            // will it *ever* fit?
+            if (size > from.limit) {
+                // no; forbid it for this simple collector
+                throw Heap.OOME;
+            }
+            // we need to trigger a collection manually
+            final ptr<thread_native> gcThread = getThreadNativePtr(Gc.gc_thread);
+            enterSafePoint(currentThreadNativePtr(), STATE_SAFEPOINT_REQUEST_GC | STATE_SAFEPOINT_REQUEST, 0);
+            // signal to the GC thread that we want a GC
+            requestSafePoint(gcThread, STATE_SAFEPOINT_REQUEST_GC);
+            // now wait for it to finish
+            exitSafePoint(currentThreadNativePtr(), 0, 0);
+            // retry the allocation
+            ptr = region_allocate(addr_of(from), size);
+            // now if it's null, we've done all we can
+            if (ptr == null) {
+                throw Heap.OOME;
+            }
+        }
+        return reference.of(ptrToRef(ptr));
+    }
+
+    @export
+    private static void relocate_objects() {
+        struct_region_iter sri = auto();
+        region_iter_init(addr_of(sri), addr_of(from));
+
+        ptr<?> ptr;
+        while ((ptr = region_iter_next(addr_of(sri))) != null) {
+            final reference<?> ref = reference.of(ptrToRef(ptr));
+            if (isMarked(ref)) {
+                move_object(ref, addr_of(to));
+            }
+        }
+    }
+}

--- a/java.base/src/main/java/jdk/internal/sys/posix/SysMman.java
+++ b/java.base/src/main/java/jdk/internal/sys/posix/SysMman.java
@@ -13,25 +13,25 @@ import org.qbicc.runtime.Build;
 public final class SysMman {
     private SysMman() {}
 
-    public static native void_ptr mmap(void_ptr addr, size_t length, c_int prot, c_int flags, c_int fd, off_t offset);
-    public static native c_int munmap(void_ptr addr, size_t length);
+    public static native <P extends ptr<?>> P mmap(ptr<?> addr, size_t length, c_int prot, c_int flags, c_int fd, off_t offset);
+    public static native c_int munmap(ptr<?> addr, size_t length);
 
-    public static native c_int mprotect(void_ptr addr, size_t length, c_int prot);
+    public static native c_int mprotect(ptr<?> addr, size_t length, c_int prot);
 
-    public static native c_int mlock(const_void_ptr addr, size_t length);
-    public static native c_int munlock(const_void_ptr addr, size_t length);
+    public static native c_int mlock(ptr<@c_const ?> addr, size_t length);
+    public static native c_int munlock(ptr<@c_const ?> addr, size_t length);
 
     public static native c_int mlockall(c_int flags);
     public static native c_int munlockall();
 
-    public static native c_int msync(void_ptr addr, size_t length, c_int flags);
+    public static native c_int msync(ptr<?> addr, size_t length, c_int flags);
 
-    public static native c_int posix_madvise(void_ptr addr, size_t length, c_int advice);
+    public static native c_int posix_madvise(ptr<?> addr, size_t length, c_int advice);
 
-    public static native c_int posix_mem_offset(const_void_ptr addr, size_t length, off_t_ptr offsetPtr, size_t_ptr contigLen, int_ptr fdPtr);
+    public static native c_int posix_mem_offset(ptr<@c_const ?> addr, size_t length, off_t_ptr offsetPtr, size_t_ptr contigLen, int_ptr fdPtr);
 
-    public static native c_int shm_open(const_char_ptr name, c_int oflag, mode_t mode);
-    public static native c_int shm_unlink(const_char_ptr name);
+    public static native c_int shm_open(ptr<@c_const c_char> name, c_int oflag, mode_t mode);
+    public static native c_int shm_unlink(ptr<@c_const c_char> name);
 
     // NOTE: Not POSIX but widely supported
     public static final c_int MAP_ANON = constant();
@@ -40,7 +40,7 @@ public final class SysMman {
     public static final c_int MAP_PRIVATE = constant();
     public static final c_int MAP_FIXED = constant();
 
-    public static final void_ptr MAP_FAILED = constant();
+    public static final ptr<?> MAP_FAILED = constant();
 
     public static final c_int PROT_READ = constant();
     public static final c_int PROT_WRITE = constant();

--- a/java.base/src/main/java/jdk/internal/thread/ObjectAccess.java
+++ b/java.base/src/main/java/jdk/internal/thread/ObjectAccess.java
@@ -1,0 +1,9 @@
+package jdk.internal.thread;
+
+import org.qbicc.runtime.patcher.PatchClass;
+
+@PatchClass(Object.class)
+final class ObjectAccess {
+    native void monitorEnter();
+    native void monitorExit();
+}

--- a/java.base/src/main/java/jdk/internal/thread/ShutdownAccess.java
+++ b/java.base/src/main/java/jdk/internal/thread/ShutdownAccess.java
@@ -1,0 +1,8 @@
+package jdk.internal.thread;
+
+import org.qbicc.runtime.patcher.Patch;
+
+@Patch("java/lang/Shutdown")
+final class ShutdownAccess {
+    static native void exit(final int code);
+}

--- a/java.base/src/main/java/jdk/internal/thread/ThreadAccess.java
+++ b/java.base/src/main/java/jdk/internal/thread/ThreadAccess.java
@@ -1,0 +1,14 @@
+package jdk.internal.thread;
+
+import static jdk.internal.thread.ThreadNative.*;
+import static org.qbicc.runtime.CNative.*;
+
+import org.qbicc.runtime.patcher.PatchClass;
+
+@PatchClass(Thread.class)
+final class ThreadAccess {
+    static int CONFIG_LOCKED;
+    static int CONFIG_DAEMON;
+    ptr<thread_native> threadNativePtr;
+    volatile int config;
+}

--- a/java.base/src/main/java/jdk/internal/thread/ThreadNative.java
+++ b/java.base/src/main/java/jdk/internal/thread/ThreadNative.java
@@ -1,0 +1,961 @@
+package jdk.internal.thread;
+
+import static jdk.internal.sys.linux.Futex.*;
+import static jdk.internal.sys.posix.Errno.*;
+import static jdk.internal.sys.posix.PThread.*;
+import static jdk.internal.sys.posix.Time.*;
+import static org.qbicc.runtime.CNative.*;
+import static org.qbicc.runtime.stdc.Errno.*;
+import static org.qbicc.runtime.stdc.Stdint.*;
+import static org.qbicc.runtime.stdc.Stdlib.*;
+import static org.qbicc.runtime.stdc.Time.*;
+import static org.qbicc.runtime.unwind.LibUnwind.*;
+import static org.qbicc.runtime.unwind.Unwind.*;
+
+import java.util.concurrent.locks.LockSupport;
+
+import org.qbicc.runtime.AutoQueued;
+import org.qbicc.runtime.Build;
+import org.qbicc.runtime.Hidden;
+import org.qbicc.runtime.Inline;
+import org.qbicc.runtime.InlineCondition;
+import org.qbicc.runtime.NoSafePoint;
+import org.qbicc.runtime.NoSideEffects;
+import org.qbicc.runtime.NoThrow;
+import org.qbicc.runtime.ThreadScoped;
+
+/**
+ * Native aspects of threads which are shared in the JDK.
+ */
+public final class ThreadNative {
+    /**
+     * Get the system thread group object.
+     *
+     * @return the system thread group (not {@code null})
+     */
+    public static native ThreadGroup getSystemThreadGroup();
+
+    /**
+     * Mutex that protects the running thread doubly-linked list.
+     */
+    @SuppressWarnings("unused")
+    public static final pthread_mutex_t thread_list_mutex = zero();
+    /**
+     * The special thread list terminus node.
+     */
+    public static final thread_native thread_list_terminus = zero();
+    // JVMTI flag definitions; this is our thread state. Here are the constraints:
+    // - no more than one of STATE_WAITING, STATE_BLOCKED_ON_MONITOR_ENTER, or STATE_RUNNABLE may be set at once
+    // - no more than one of STATE_WAITING_INDEFINITELY or STATE_WAITING_WITH_TIMEOUT may be set at once
+    // - no more than one of STATE_IN_OBJECT_WAIT, STATE_PARKED, or STATE_SLEEPING may be set at once
+    // - if any of STATE_INTERRUPTED or STATE_IN_NATIVE is set, then STATE_ALIVE is set
+    // - no more than one of STATE_ALIVE or STATE_TERMINATED may be set at once
+
+    // ==================================
+    //  State Flags
+    //    These flag bits align with the
+    //    corresponding JVMTI bit numbers.
+    // ==================================
+
+    // ----------------------------------
+    //  Liveness status flags
+    //    0 or 1 of these may be set
+    // ----------------------------------
+
+    /**
+     * Thread is alive (has been started).
+     * Mutually exclusive with {@link #STATE_TERMINATED}.
+     */
+    public static final int STATE_ALIVE = 1 << 0;
+    /**
+     * Thread is terminated (has exited after being started).
+     * Mutually exclusive with {@link #STATE_ALIVE}.
+     */
+    public static final int STATE_TERMINATED = 1 << 1;
+
+    // ----------------------------------
+    //  Terminated state flags
+    //    0 or 1 of these may be set
+    //    (STATE_TERMINATED is set)
+    // ----------------------------------
+
+    /**
+     * Thread has exited.
+     * May only be set while {@link #STATE_TERMINATED} is set.
+     */
+    public static final int STATE_EXITED = 1 << 27;
+
+    // ----------------------------------
+    //  Alive state flags
+    //    Exactly 1 must be set
+    //    (STATE_ALIVE is set)
+    // ----------------------------------
+
+    /**
+     * Thread is runnable.
+     * May only be set while {@link #STATE_ALIVE} is set.
+     * Mutually exclusive with {@link #STATE_WAITING} and {@link #STATE_BLOCKED_ON_MONITOR_ENTER}.
+     */
+    public static final int STATE_RUNNABLE = 1 << 2;
+    /**
+     * The thread is waiting for something (is not currently runnable).
+     * May only be set while {@link #STATE_ALIVE} is set.
+     * Mutually exclusive with {@link #STATE_RUNNABLE} and {@link #STATE_BLOCKED_ON_MONITOR_ENTER}.
+     */
+    public static final int STATE_WAITING = 1 << 7;
+
+    // ----------------------------------
+    //  Waiting reason flags
+    //    0 or 1 may be set while WAITING
+    // ----------------------------------
+
+    /**
+     * The thread is blocked waiting to acquire or reacquire an object monitor.
+     * May only be set while {@link #STATE_ALIVE} is set.
+     * Mutually exclusive with {@link #STATE_RUNNABLE} and {@link #STATE_WAITING}.
+     */
+    public static final int STATE_BLOCKED_ON_MONITOR_ENTER = 1 << 10;
+    /**
+     * The thread is waiting without a timeout.
+     * May only be set while {@link #STATE_WAITING} is set.
+     * Mutually exclusive with {@link #STATE_WAITING_WITH_TIMEOUT}.
+     */
+    public static final int STATE_WAITING_INDEFINITELY = 1 << 4;
+    /**
+     * The thread is waiting with a timeout.
+     * May only be set while {@link #STATE_WAITING} is set.
+     * Mutually exclusive with {@link #STATE_WAITING_INDEFINITELY}.
+     */
+    public static final int STATE_WAITING_WITH_TIMEOUT = 1 << 5;
+    /**
+     * The thread is asleep (i.e. in {@link Thread#sleep(long)} or {@link Thread#sleep(long, int)}).
+     * May only be set while {@link #STATE_WAITING} is set.
+     * Mutually exclusive with {@link #STATE_IN_OBJECT_WAIT} and {@link #STATE_PARKED}.
+     */
+    public static final int STATE_SLEEPING = 1 << 6;
+    /**
+     * The thread is waiting on an object's monitor.
+     * May only be set while {@link #STATE_WAITING} is set.
+     * Mutually exclusive with {@link #STATE_SLEEPING} and {@link #STATE_PARKED}.
+     */
+    public static final int STATE_IN_OBJECT_WAIT = 1 << 8;
+    /**
+     * The thread is waiting in one of the {@link LockSupport} park methods.
+     * May only be set while {@link #STATE_WAITING} is set.
+     * Mutually exclusive with {@link #STATE_SLEEPING} and {@link #STATE_IN_OBJECT_WAIT}.
+     */
+    public static final int STATE_PARKED = 1 << 9;
+    // STATE_SUSPENDED = 1 << 20;
+
+    // ----------------------------------
+    //  Run-time notification flags
+    //    0 or more may be set while ALIVE
+    //    Affects running thread state
+    // ----------------------------------
+
+    /**
+     * The unpark permit.
+     * If set, then a {@code LockSupport.park()} will consume the permit rather than park.
+     * Other forms of {@code park} and other blocking operations are unaffected.
+     * May only be set while {@link #STATE_ALIVE} is set.
+     * Normally clear.
+     * This is an inbound-notification flag.
+     * This bit is unused by JVMTI.
+     */
+    public static final int STATE_UNPARK = 1 << 11; // unused by JVMTI
+    /**
+     * The interrupt flag.
+     * If set, then interruptible blocking operations will return immediately or throw an interruption exception.
+     * Other blocking operations are unaffected.
+     * May only be set while {@link #STATE_ALIVE} is set.
+     * Normally clear.
+     * This is an inbound-notification flag.
+     */
+    public static final int STATE_INTERRUPTED = 1 << 21;
+
+    // ----------------------------------
+    //  Thread safepoint state flags
+    // ----------------------------------
+
+    /**
+     * The in-native flag.
+     * If set, then a native method is running.
+     * Native methods may also run without setting this flag.
+     * May only be set while {@link #STATE_IN_SAFEPOINT} is set.
+     * Normally clear.
+     * No notifications are associated with this flag.
+     */
+    public static final int STATE_IN_NATIVE = 1 << 22;
+    /**
+     * The thread state bit mask which reflects the bits that are valid to JVMTI.
+     */
+    public static final int JVMTI_STATE_BITS = 0
+        | STATE_ALIVE
+        | STATE_TERMINATED
+        | STATE_RUNNABLE
+        | STATE_WAITING_INDEFINITELY
+        | STATE_WAITING_WITH_TIMEOUT
+        | STATE_SLEEPING
+        | STATE_WAITING
+        | STATE_IN_OBJECT_WAIT
+        | STATE_PARKED
+        | STATE_BLOCKED_ON_MONITOR_ENTER
+     // | STATE_SUSPENDED
+        | STATE_INTERRUPTED
+        | STATE_IN_NATIVE
+        ;
+    /**
+     * The in-safepoint flag.
+     * If set, then the thread is in a safepoint.
+     * A thread may cooperatively enter a safepoint at any time.
+     * A thread may not exit the safepoint state until the {@link #STATE_SAFEPOINT_REQUEST} flag is clear.
+     * May only be set while {@link #STATE_ALIVE} is set.
+     * This is an outbound-notification flag.
+     * This bit corresponds to the JVMTI "vendor 1" bit.
+     */
+    public static final int STATE_IN_SAFEPOINT = 1 << 28;
+
+    // ----------------------------------
+    //  Thread safepoint request flags
+    // ----------------------------------
+
+    // STATE_SAFEPOINT_REQUEST_SUSPEND = 1 << ??;
+    /**
+     * The safepoint-request flag for GC.
+     * If set, then the thread is participating in garbage collection and may not exit a safepoint.
+     * Normally clear.
+     * The thread may atomically set its own request-GC flag and park in a safepoint if it cannot complete an allocation.
+     * The GC thread(s) may set this flag and perform GC work from within a safepoint.
+     * May only be set while {@link #STATE_ALIVE} is set.
+     * No notifications are associated with this flag.
+     * This bit corresponds to the JVMTI "vendor 2" bit.
+     */
+    public static final int STATE_SAFEPOINT_REQUEST_GC = 1 << 29;
+    /**
+     * The safepoint-request flag for thread stack walking.
+     * If set, then the thread is participating in stack capture and may not exit a safepoint.
+     * This flag must be owned exclusively by one thread to prevent premature safepoint exits.
+     * Use a monitor to ensure exclusive access.
+     * Normally clear.
+     * May only be set while {@link #STATE_ALIVE} is set.
+     * No notifications are associated with this flag.
+     * This bit corresponds to the JVMTI "vendor 3" bit.
+     */
+    public static final int STATE_SAFEPOINT_REQUEST_STACK = 1 << 30;
+    /**
+     * A mask containing the bits of all the specific safepoint-request flags.
+     */
+    public static final int STATE_SAFEPOINT_REQUEST_ANY = STATE_SAFEPOINT_REQUEST_GC | STATE_SAFEPOINT_REQUEST_STACK;
+    /**
+     * The general safepoint-request flag.
+     * This flag must be set whenever any of the other {@code #PARK_SAFEPOINT_REQUEST_*} flags are set.
+     * This is because CPUs generally have a single instruction to detect a negative number, making polling more efficient.
+     * May only be set while {@link #STATE_ALIVE} is set.
+     * This is an inbound-notification flag.
+     * This bit is unused by JVMTI.
+     */
+    public static final int STATE_SAFEPOINT_REQUEST = 1 << 31;
+    /**
+     * Thread number counter for generation of thread names.
+     */
+    @SuppressWarnings("unused")
+    public static volatile int threadNumberCounter;
+    /* For generating thread ID */
+    @SuppressWarnings("unused")
+    public static volatile long threadSeqNumber;
+    /**
+     * The number of non-daemon threads; when this reaches zero, we exit.
+     */
+    @SuppressWarnings("unused")
+    public static volatile int nonDaemonThreadCount;
+    @SuppressWarnings("unused")
+    public static volatile int shutdownInitiated;
+    /**
+     * Internal holder for the current thread.
+     */
+    @export
+    @ThreadScoped
+    public static ptr<thread_native> _qbicc_bound_java_thread;
+
+    private ThreadNative() {}
+
+    static {
+        thread_list_terminus.next = addr_of(thread_list_terminus);
+        thread_list_terminus.prev = addr_of(thread_list_terminus);
+    }
+
+    @NoSafePoint
+    @NoSideEffects
+    @NoThrow
+    @Hidden
+    public static native ptr<thread_native> currentThreadNativePtr();
+
+    public static int nextThreadNum() {
+        return addr_of(threadNumberCounter).getAndAdd(word(1)).intValue();
+    }
+
+    public static void notifySafePointOutbound(final ptr<thread_native> threadNativePtr) {
+        final ptr<uint32_t> statePtr = addr_of(deref(threadNativePtr).state);
+        if (Build.Target.isLinux()) {
+            futex_wake_all(statePtr);
+        } else if (Build.Target.isWasi()) {
+            // TODO
+            //  memory.atomic.notify(statusPtr, 1)
+            abort();
+        } else if (Build.Target.isPosix()) {
+            if (pthread_cond_signal(addr_of(deref(threadNativePtr).outbound_cond)).isNonZero()) abort();
+        }
+    }
+
+    public static void monitorEnter(Object obj) {
+        if (obj == null) {
+            throw new NullPointerException();
+        }
+        // todo: stack-locking or similar
+        ObjectAccess oa = cast(obj);
+        oa.monitorEnter();
+    }
+
+    public static void monitorExit(Object obj) {
+        if (obj == null) {
+            throw new NullPointerException();
+        }
+        // todo: stack-locking or similar
+        ObjectAccess oa = cast(obj);
+        oa.monitorExit();
+    }
+
+    /**
+     * A pointer to this function is passed to pthread_create by start0.
+     * The role of this wrapper is to transition a newly started Thread from C to Java calling
+     * conventions and then invoke the Thread's run0 method.
+     * @param threadParam a reference stuffed into a pointer
+     * @return {@code null} always
+     */
+    @export(withScope = ExportScope.LOCAL)
+    @Hidden
+    public static ptr<?> runThreadBody(ptr<?> threadParam) {
+        pthread_detach(pthread_self());
+        ptr<thread_native> threadNativePtr = threadParam.cast();
+        _qbicc_bound_java_thread = threadNativePtr;
+        bind(threadNativePtr);
+        // not reachable
+        abort();
+        return null;
+    }
+
+    /**
+     * Attach an unstarted thread and run the given method body under the thread.
+     *
+     * @param thread the thread to attach
+     */
+    @export
+    @NoThrow
+    @Hidden
+    public static void thread_attach(Thread thread) {
+        ThreadAccess ta = cast(thread);
+        ptr<thread_native> threadNativePtr = ta.threadNativePtr;
+        if (threadNativePtr.isNonNull()) {
+            // we cannot recover
+            abort();
+        }
+        threadNativePtr = malloc(sizeof(thread_native.class));
+        if (threadNativePtr.isNull()) {
+            // not enough memory to start
+            abort();
+        }
+        // zero-init the whole structure
+        threadNativePtr.storeUnshared(zero());
+        if (Build.Target.isPosix()) {
+            if (! Build.Target.isLinux() && ! Build.Target.isWasm()) {
+                if (pthread_mutex_init(addr_of(deref(threadNativePtr).mutex), zero()).isNonZero()) abort();
+                if (pthread_cond_init(addr_of(deref(threadNativePtr).inbound_cond), zero()).isNonZero()) abort();
+                if (pthread_cond_init(addr_of(deref(threadNativePtr).outbound_cond), zero()).isNonZero()) abort();
+            }
+        }
+        deref(threadNativePtr).ref = reference.of(thread);
+        // register it on to this thread *before* the safepoint
+        if (addr_of(deref(refToPtr(ta)).threadNativePtr).compareAndSwap(zero(), threadNativePtr).isNonNull()) {
+            // lost the race :(
+            // release the mutex and conditions
+            if (Build.Target.isPosix()) {
+                if (! Build.Target.isLinux() && ! Build.Target.isWasm()) {
+                    if (pthread_cond_destroy(addr_of(deref(threadNativePtr).outbound_cond)).isNonZero()) abort();
+                    if (pthread_cond_destroy(addr_of(deref(threadNativePtr).inbound_cond)).isNonZero()) abort();
+                    if (pthread_mutex_destroy(addr_of(deref(threadNativePtr).mutex)).isNonZero()) abort();
+                }
+            }
+            free(threadNativePtr);
+            abort();
+        }
+        _qbicc_bound_java_thread = threadNativePtr;
+
+        // initialize status
+        deref(threadNativePtr).state = word(STATE_ALIVE);
+
+        int oldVal;
+        int newVal;
+        int witness;
+
+        // lock in the config
+        final ptr<int32_t> configPtr = addr_of(deref(refToPtr(ta)).config);
+        oldVal = configPtr.loadSingleAcquire().intValue();
+        for (;;) {
+            if ((oldVal & ThreadAccess.CONFIG_LOCKED) != 0) {
+                // should not be possible, but it's a valid state
+                if ((oldVal & ThreadAccess.CONFIG_DAEMON) != 0) {
+                    // the main thread may not be a daemon thread
+                    abort();
+                }
+                break;
+            }
+            newVal = oldVal | ThreadAccess.CONFIG_LOCKED;
+            witness = configPtr.compareAndSwapRelease(word(oldVal), word(newVal)).intValue();
+            if (witness == oldVal) {
+                break;
+            }
+            oldVal = witness;
+        }
+        // manually register the thread count
+        addr_of(nonDaemonThreadCount).getAndAdd(word(1));
+
+        // add thread to linked list; note that unlike `start`, we do not safepoint here
+        // acquire lock
+        if (Build.Target.isPosix()) {
+            if (pthread_mutex_lock(addr_of(thread_list_mutex)).isNonZero()) abort();
+        } else {
+            // ???
+            abort();
+        }
+        // we hold the big list lock; do ye olde linked list insertion
+        deref(thread_list_terminus.prev).next = threadNativePtr;
+        deref(threadNativePtr).prev = thread_list_terminus.prev;
+        thread_list_terminus.prev = threadNativePtr;
+        deref(threadNativePtr).next = addr_of(thread_list_terminus);
+        // release lock
+        if (Build.Target.isPosix()) {
+            if (pthread_mutex_unlock(addr_of(thread_list_mutex)).isNonZero()) abort();
+        } else {
+            // ???
+            abort();
+        }
+
+        // The thread is now alive; use the normal execution methodology from now on
+        bind(threadNativePtr);
+        // (not reachable)
+        abort();
+    }
+
+    @NoSafePoint
+    @NoThrow
+    public static ptr<thread_native> getThreadNativePtr(Thread thread) {
+        ThreadAccess ta = cast(thread);
+        return ta.threadNativePtr;
+    }
+
+    public static void exitNonDaemonThread() {
+        // todo: put the shutdown bit right on the count word?
+        int cnt = addr_of(nonDaemonThreadCount).getAndAdd(word(- 1)).intValue();
+        if (cnt == 1) {
+            boolean shouldShutdown = addr_of(shutdownInitiated).compareAndSet(word(0), word(1));
+            if (shouldShutdown) {
+                // start a new exiter thread to avoid blocking Thread.start()
+                new Thread(() -> ShutdownAccess.exit(0), "Exit thread").start();
+            }
+        }
+    }
+
+    @NoSafePoint
+    public static void freeThreadNative(ptr<thread_native> threadNativePtr) {
+        // assert threadNativePtr != null;
+        if (Build.Target.isPosix() && ! Build.Target.isLinux() && ! Build.Target.isWasm()) {
+            // destroy our conditions and mutex
+            pthread_cond_destroy(addr_of(deref(threadNativePtr).inbound_cond));
+            pthread_cond_destroy(addr_of(deref(threadNativePtr).outbound_cond));
+            pthread_mutex_destroy(addr_of(deref(threadNativePtr).mutex));
+        }
+        // release the memory
+        free(threadNativePtr);
+    }
+
+    // intrinsic, but implies Hidden & NoThrow & NoReturn
+    public static native void bind(ptr<thread_native> threadPtr);
+
+    @NoSafePoint
+    public static long nextThreadID() {
+        return addr_of(threadSeqNumber).getAndAdd(word(1)).longValue();
+    }
+
+    /**
+     * Park in a safepoint for some amount of time.
+     *
+     * @param millis the number of milliseconds to park for
+     * @param nanos the number of nanos to park for
+     * @param setBits the bits to set while parking
+     * @param clearBits the bits to clear while parking
+     * @param wakeBits the set of bits, any of which should cause the park to return early
+     * @param clearWakeBits the set of bits to clear on unpark and cause the park to return early
+     */
+    @SuppressWarnings("ConstantConditions")
+    @NoSafePoint
+    @Hidden
+    public static void park(long millis, int nanos, int setBits, int clearBits, int wakeBits, int clearWakeBits) {
+        if (millis < 0 || nanos < 0 || nanos > 999_999) {
+            throw new IllegalArgumentException();
+        }
+        // assert
+        final ptr<thread_native> threadNativePtr = currentThreadNativePtr();
+        final ptr<uint32_t> statePtr = addr_of(deref(threadNativePtr).state);
+        // check to see if we should just exit right away
+        if ((statePtr.loadSingleAcquire().intValue() & wakeBits) != 0) {
+            return;
+        }
+        if (Build.Target.isPosix()) {
+            // POSIX park uses seconds not millis...
+            long posixSeconds = millis / 1_000L;
+            int posixNanos = nanos + ((int)millis % 1_000) * 1_000_000;
+            parkPosix(posixSeconds, posixNanos, setBits, clearBits, wakeBits, clearWakeBits);
+        } else {
+            // todo
+            abort();
+        }
+    }
+
+    @SuppressWarnings("ConstantConditions")
+    @NoSafePoint
+    @NoThrow
+    @Hidden
+    public static void parkPosix(long seconds, int nanos, int setBits, int clearBits, int wakeBits, int clearWakeBits) {
+        struct_timespec ts = auto();
+        struct_timespec now = auto();
+        final ptr<thread_native> threadNativePtr = currentThreadNativePtr();
+        final ptr<uint32_t> statePtr = addr_of(deref(threadNativePtr).state);
+        enterSafePoint(threadNativePtr, setBits, clearBits);
+        // we are now ready to park
+
+        // wait for any of the bits to be set
+        if (! Build.Target.isLinux()) {
+            // acquire the mutex
+            if (pthread_mutex_lock(addr_of(deref(threadNativePtr).mutex)).isNonZero()) abort();
+        }
+        if (seconds != 0 || nanos != 0) {
+            // get the start time; both Linux and not-linux are absolute but the clock used varies
+            clock_gettime(Build.Target.isLinux() ? CLOCK_MONOTONIC : CLOCK_REALTIME, addr_of(now));
+            // add the base time to the duration
+            nanos += now.tv_nsec.intValue();
+            if (nanos > 1_000_000_000) {
+                // carry the one
+                seconds ++;
+                nanos -= 1_000_000_000;
+            }
+            seconds += now.tv_sec.longValue();
+            // store it back
+            ts.tv_sec = word(seconds);
+            ts.tv_nsec = word(nanos);
+        }
+        wakeBits |= clearWakeBits;
+        int oldVal = statePtr.loadSingleAcquire().intValue();
+        while ((oldVal & wakeBits) == 0) {
+            // wait
+            if (seconds != 0 || nanos != 0) {
+                if (Build.Target.isLinux()) {
+                    futex_wait_bits(statePtr, word(wakeBits), word(wakeBits), addr_of(ts));
+                } else {
+                    final c_int res = pthread_cond_timedwait(addr_of(deref(threadNativePtr).inbound_cond), addr_of(deref(threadNativePtr).mutex), addr_of(ts));
+                    if (res.isNonZero() && res != ETIMEDOUT) abort();
+                }
+            } else {
+                if (Build.Target.isLinux()) {
+                    futex_wait_bits(statePtr, word(wakeBits), word(wakeBits), zero());
+                } else {
+                    if (pthread_cond_wait(addr_of(deref(threadNativePtr).inbound_cond), addr_of(deref(threadNativePtr).mutex)).isNonZero()) abort();
+                }
+            }
+            // check the bits
+            oldVal = statePtr.loadSingleAcquire().intValue();
+            if ((oldVal & wakeBits) != 0) {
+                // done (awoken)
+                break;
+            }
+            if (seconds != 0 || nanos != 0) {
+                // check the time
+                clock_gettime(Build.Target.isLinux() ? CLOCK_MONOTONIC : CLOCK_REALTIME, addr_of(now));
+                if (now.tv_sec.longValue() > ts.tv_sec.longValue() || now.tv_sec == ts.tv_sec && now.tv_nsec.intValue() >= ts.tv_nsec.intValue()) {
+                    // done (timeout)
+                    break;
+                }
+            }
+        }
+        // unlock
+        if (! Build.Target.isLinux()) {
+            // release the mutex
+            if (pthread_mutex_unlock(addr_of(deref(threadNativePtr).mutex)).isNonZero()) abort();
+        }
+        // todo: this reacquires the mutex right away; maybe introduce a "locked" version to avoid this
+        exitSafePoint(threadNativePtr, clearBits, setBits | clearWakeBits);
+    }
+
+    /**
+     * Request that a thread enter into a safepoint.
+     * Within a safepoint, a thread may not access the VM heap in any way (including allocation).
+     * On return, the thread was requested to enter a safepoint.
+     *
+     * @param setBits the {@code STATE_*} flag that indicates the reason for the safepoint
+     */
+    @NoSafePoint
+    @Hidden
+    @NoThrow
+    public static void requestSafePoint(ptr<thread_native> threadNativePtr, int setBits) {
+        // assert Integer.bitCount(reason) == 1;
+        // assert Thread.currentThread() != threadNativePtr->ref
+        final ptr<uint32_t> statusPtr = addr_of(deref(threadNativePtr).state);
+        setBits |= STATE_SAFEPOINT_REQUEST;
+        int witness;
+        int oldVal = statusPtr.loadVolatile().intValue();
+        for (;;) {
+            if ((oldVal & setBits) == setBits) {
+                // already set
+                return;
+            }
+            witness = statusPtr.compareAndSwap(word(oldVal), word(oldVal | setBits)).intValue();
+            if (witness == oldVal) {
+                // done; wake it up if it is sleeping
+                if (Build.Target.isLinux()) {
+                    futex_wake_all(statusPtr);
+                } else if (Build.Target.isWasi()) {
+                    // TODO
+                    //  memory.atomic.notify(statusPtr, 1)
+                    abort();
+                } else if (Build.Target.isPosix()) {
+                    if (pthread_cond_broadcast(addr_of(deref(threadNativePtr).inbound_cond)).isNonZero()) abort();
+                }
+                return;
+            }
+            oldVal = witness;
+        }
+    }
+
+    /**
+     * Release a safepoint for another thread.
+     * The bits given should be the same as the one given to {@link #requestSafePoint}.
+     *
+     * @param clearBits the {@code STATE_*} flag that indicates the reason for the safepoint
+     */
+    @NoSafePoint
+    @Hidden
+    @NoThrow
+    public static void releaseSafePoint(final ptr<thread_native> threadNativePtr, int clearBits) {
+        // assert Integer.bitCount(reason) == 1;
+        final ptr<uint32_t> statusPtr = addr_of(deref(threadNativePtr).state);
+        int witness;
+        int oldVal = statusPtr.loadVolatile().intValue();
+        int newVal;
+        for (;;) {
+            newVal = oldVal & ~clearBits;
+            if ((newVal & STATE_SAFEPOINT_REQUEST_ANY) == 0) {
+                // case 1: we were the last reason for safepoint
+                newVal &= ~STATE_SAFEPOINT_REQUEST;
+                witness = statusPtr.compareAndSwap(word(oldVal), word(newVal)).intValue();
+                if (witness == oldVal) {
+                    // done; now we must signal the thread so it can exit the safepoint
+                    if (Build.Target.isLinux()) {
+                        futex_wake_all(statusPtr);
+                    } else if (Build.Target.isWasi()) {
+                        // TODO
+                        //  memory.atomic.notify(statusPtr, 1)
+                        abort();
+                    } else if (Build.Target.isPosix()) {
+                        if (pthread_cond_broadcast(addr_of(deref(threadNativePtr).inbound_cond)).isNonZero()) abort();
+                    }
+                    return;
+                }
+            } else {
+                // case 2: other safepoint reasons are still in effect; just clear the bit and return
+                witness = statusPtr.compareAndSwap(word(oldVal), word(newVal)).intValue();
+                if (witness == oldVal) {
+                    // done
+                    return;
+                }
+            }
+            oldVal = witness;
+        }
+    }
+
+    /**
+     * Wait until the given thread is in a safepoint.
+     * Must not be called from within the same thread.
+     * May only be called within a safepoint.
+     */
+    @NoSafePoint
+    @Hidden
+    @NoThrow
+    public static void awaitSafePoint(ptr<thread_native> threadNative) {
+        awaitStatusWord(threadNative, STATE_IN_SAFEPOINT);
+    }
+
+    @NoSafePoint
+    @Hidden
+    @NoThrow
+    public static void awaitStatusWord(ptr<thread_native> threadNative, int bits) {
+        awaitStatusWord(threadNative, bits, bits);
+    }
+
+    @NoSafePoint
+    @Hidden
+    @NoThrow
+    public static int awaitStatusWord(ptr<thread_native> threadNative, int mask, int bits) {
+        // assert isSafePoint();
+        final ptr<uint32_t> statusPtr = addr_of(deref(threadNative).state);
+        int state = statusPtr.loadVolatile().intValue();
+        while ((state & mask) != bits) {
+            if (Build.Target.isLinux()) {
+                // use futex operations to await our desired bit pattern
+                if (! futex_wait_bits(statusPtr, word(mask), word(bits), zero()) && errno != EINTR.intValue()) {
+                    // fatal error
+                    abort();
+                }
+            } else if (Build.Target.isWasi()) {
+                // TODO
+                //  memory.atomic.wait32(statusPtr, state & mask | bits, -1)
+                abort();
+            } else if (Build.Target.isPosix()) {
+                // double-checked pattern, but using pthread_mutex
+                int res = pthread_mutex_lock(addr_of(deref(threadNative).mutex)).intValue();
+                if (res != 0) {
+                    // fatal error
+                    abort();
+                }
+                state = statusPtr.loadVolatile().intValue();
+                while ((state & mask) != bits) {
+                    res = pthread_cond_wait(addr_of(deref(threadNative).outbound_cond), addr_of(deref(threadNative).mutex)).intValue();
+                    if (res != 0) {
+                        // fatal error
+                        abort();
+                    }
+                    state = statusPtr.loadVolatile().intValue();
+                }
+                res = pthread_mutex_unlock(addr_of(deref(threadNative).mutex)).intValue();
+                if (res != 0) {
+                    // fatal error
+                    abort();
+                }
+                // done by interior loop
+                return state;
+            }
+            state = statusPtr.loadVolatile().intValue();
+        }
+        return state;
+    }
+
+    /**
+     * Poll for a safepoint.
+     */
+    @NoSafePoint
+    @Hidden
+    @Inline(InlineCondition.ALWAYS)
+    @NoThrow
+    @AutoQueued
+    public static void pollSafePoint() {
+        final ptr<thread_native> threadNativePtr = currentThreadNativePtr();
+        final int threadStatus = addr_of(deref(threadNativePtr).state).loadAcquire().intValue();
+        if (threadStatus < 0) {
+            externalSafePoint(threadNativePtr);
+        }
+    }
+
+    /**
+     * Do the work of an externally-triggered safepoint.
+     */
+    @NoSafePoint
+    @Hidden
+    @Inline(InlineCondition.NEVER)
+    @NoThrow
+    public static void externalSafePoint(final ptr<thread_native> threadNativePtr) {
+        enterSafePoint(threadNativePtr, 0, 0);
+        exitSafePoint(threadNativePtr, 0, 0);
+    }
+
+    /**
+     * Enter a safepoint voluntarily from the current thread.
+     * While in a safepoint, the thread execution state will not change.
+     * However, the interrupt or unpark flags may be asynchronously set on a safepointed thread.
+     * The {@code reason} parameter must either be zero or a combination of {@link #STATE_SAFEPOINT_REQUEST} and
+     * one or more {@code PARK_SAFEPOINT_REQUEST_*} flags; otherwise, the thread will be trapped in a safepoint indefinitely.
+     *
+     * @param threadNativePtr the pointer to the thread's native structure (must not be {@code null})
+     * @param setBits an optional set of bits to add to the status
+     * @param clearBits an optional set of bits to remove from the status
+     */
+    @NoSafePoint
+    @Hidden
+    @NoThrow
+    public static void enterSafePoint(ptr<thread_native> threadNativePtr, int setBits, int clearBits) {
+        // XXX WARNING: Thread.currentThread() is INVALID in this method XXX
+        // the reason is that GC may relocate it, but this method is not in the captured context so stack walk will miss it
+
+        final ptr<uint32_t> statusPtr = addr_of(deref(threadNativePtr).state);
+
+        // capture our state
+        // todo: if (Build.Target.isUnwContext) ...
+        if (unw_getcontext(addr_of(deref(threadNativePtr).saved_context)).isNonZero()) abort();
+
+        // now, indicate that we are in a safepoint
+        int witness = statusPtr.loadVolatile().intValue();
+        int oldVal, newVal;
+        do {
+            oldVal = witness;
+            // no need to check oldVal, since we cannot be in a safepoint
+            // assert (oldVal & (STATE_EXITED | STATE_IN_SAFEPOINT)) == 0;
+            newVal = (oldVal & ~clearBits) | STATE_IN_SAFEPOINT | setBits;
+            witness = statusPtr.compareAndSwap(word(oldVal), word(newVal)).intValue();
+        } while (witness != oldVal);
+        // notify waiters (if any)
+        if (Build.Target.isLinux()) {
+            futex_wake_all(statusPtr);
+        } else if (Build.Target.isWasi()) {
+            // TODO
+            //  memory.atomic.notify(statusPtr, Integer.MAX_VALUE)
+            abort();
+        } else if (Build.Target.isPosix()) {
+            // signal after transition
+            if (pthread_cond_broadcast(addr_of(deref(threadNativePtr).outbound_cond)).intValue() != 0) abort();
+        }
+    }
+
+    @NoSafePoint
+    @Hidden
+    public static int exitSafePoint(ptr<thread_native> threadNativePtr, int setBits, int clearBits) {
+        // XXX WARNING: Thread.currentThread() is INVALID in this method XXX
+        // the reason is that GC may relocate it, but this method is not in the captured context so stack walk will miss it
+
+        final ptr<uint32_t> statusPtr = addr_of(deref(threadNativePtr).state);
+        // wait until it's OK to exit the safepoint
+        // assert isSafePoint();
+        if (Build.Target.isPosix() && ! Build.Target.isLinux() && ! Build.Target.isWasi()) {
+            // double-checked pattern, but using pthread_mutex; also, we need the lock for waiting
+            int res = pthread_mutex_lock(addr_of(deref(threadNativePtr).mutex)).intValue();
+            if (res != 0) {
+                // fatal error
+                abort();
+            }
+        }
+        int oldVal = statusPtr.loadVolatile().intValue();
+        for (;;) {
+            while ((oldVal & STATE_SAFEPOINT_REQUEST) != 0) {
+                if (Build.Target.isLinux()) {
+                    // use futex operations to await our desired bit pattern
+                    if (! futex_wait_bits(statusPtr, word(STATE_SAFEPOINT_REQUEST), word(0), zero()) && errno != EINTR.intValue()) {
+                        // fatal error
+                        abort();
+                    }
+                } else if (Build.Target.isWasi()) {
+                    // TODO
+                    //  memory.atomic.wait32(statusPtr, state & ~STATE_SAFEPOINT_REQUEST, -1)
+                    abort();
+                } else if (Build.Target.isPosix()) {
+                    if (pthread_cond_wait(addr_of(deref(threadNativePtr).inbound_cond), addr_of(deref(threadNativePtr).mutex)).isNonZero()) abort();
+                }
+                oldVal = statusPtr.loadVolatile().intValue();
+            }
+            // the request is cleared; now, attempt to clear the safepoint state and notify waiters
+            int witness = statusPtr.compareAndSwap(word(oldVal), word(oldVal & ~STATE_IN_SAFEPOINT & ~clearBits | setBits)).intValue();
+            if (witness == oldVal) {
+                // success!
+                break;
+            }
+            // try again
+            oldVal = witness;
+        }
+        // done! notify waiters
+        if (Build.Target.isLinux()) {
+            futex_wake_all(statusPtr);
+        } else if (Build.Target.isWasi()) {
+            // TODO
+            //  memory.atomic.notify(statusPtr, Integer.MAX_VALUE)
+            abort();
+        } else if (Build.Target.isPosix()) {
+            if (pthread_cond_broadcast(addr_of(deref(threadNativePtr).outbound_cond)).isNonZero()) abort();
+            if (pthread_mutex_unlock(addr_of(deref(threadNativePtr).mutex)).isNonZero()) abort();
+        }
+        return oldVal;
+    }
+
+    // todo: move this to main?
+    @constructor
+    @export
+    public static void init_thread_list_mutex() {
+        // initialize the mutex at early run time
+        pthread_mutex_init(addr_of(thread_list_mutex), zero());
+    }
+
+    /**
+     * Structure containing thread-specific items which cannot be moved in memory.
+     * A doubly-linked list, protected by {@link ThreadNative#thread_list_mutex}, is maintained by
+     * the {@code next} and {@code prev} pointers, which are always non-{@code null}.
+     * The list link pointers may only be accessed (for read or write) under the mutex.
+     * The special node {@link ThreadNative#thread_list_terminus} indicates the start and end of the list.
+     * The {@code next} and {@code prev} pointers of that node contain the actual ends of the list.
+     * <p>
+     * This structure is allocated on thread start and freed some time after termination.
+     * Thus, it should normally only be accessed from the same thread or when thread state {@code STATE_ACTIVE} is set.
+     */
+    @internal
+    public static class thread_native extends object {
+        // TODO
+        // ptr<?> top_of_stack; // basis for compressed stack refs
+        /**
+         * The next (newer) thread link.
+         * On the terminus node, this is the <em>first (least recent)</em> node in the list.
+         */
+        public ptr<thread_native> next;
+        /**
+         * The previous (older) thread link.
+         * On the terminus node, this is the <em>last (most recent)</em> node in the list.
+         * New threads are added here.
+         */
+        public ptr<thread_native> prev;
+
+        /**
+         * The POSIX thread identifier.
+         */
+        @incomplete(unless = Build.Target.IsPThreads.class)
+        public pthread_t thread;
+
+        /**
+         * Reference to the actual Java thread. Must be updated during GC.
+         */
+        public reference<Thread> ref;
+
+        // Fallback park/unpark mutex
+
+        /**
+         * Protects {@link #state} (double-checked path) and the two conditions on platforms without lockless waiting.
+         */
+        // todo: unless = Build.Target.HasIntegerWait or similar
+        @incomplete(when = { Build.Target.IsLinux.class, Build.Target.IsWasi.class}, unless = Build.Target.IsPosix.class)
+        public pthread_mutex_t mutex;
+        /**
+         * Other threads signal this waiting thread.
+         */
+        @incomplete(when = { Build.Target.IsLinux.class, Build.Target.IsWasi.class}, unless = Build.Target.IsPosix.class)
+        public pthread_cond_t inbound_cond;
+        /**
+         * This thread signals other waiting threads.
+         */
+        @incomplete(when = { Build.Target.IsLinux.class, Build.Target.IsWasi.class}, unless = Build.Target.IsPosix.class)
+        public pthread_cond_t outbound_cond;
+
+        /**
+         * The thread state.
+         */
+        public uint32_t state;
+
+        // safepoint state
+        @incomplete(when = Build.Target.IsWasi.class)
+        public unw_context_t saved_context;
+
+        // exception info
+        // @incomplete(unless = Build.Target.IsUnwind.class)
+        public struct__Unwind_Exception unwindException;
+    }
+}

--- a/java.base/src/main/resources/META-INF/qbicc/qbicc-patch-info
+++ b/java.base/src/main/resources/META-INF/qbicc/qbicc-patch-info
@@ -48,6 +48,9 @@ java.util.concurrent.Exchanger$_init
 java.util.concurrent.Exchanger$_runtime
 java.util.concurrent.Phaser$_init
 java.util.concurrent.Phaser$_runtime
+jdk.internal.gc.ArrayAccess
+jdk.internal.gc.ClassAccess
+jdk.internal.gc.ObjectAccess
 jdk.internal.loader.BootLoader$_patch
 jdk.internal.loader.BuiltinClassLoader$_patch
 jdk.internal.misc.UnsafeConstants$_patch
@@ -55,6 +58,9 @@ jdk.internal.misc.UnsafeConstants$_runtime
 jdk.internal.misc.VM$_patch
 jdk.internal.ref.CleanerImpl$_patch
 jdk.internal.sys.linux.Linux$_runtime
+jdk.internal.thread.ObjectAccess
+jdk.internal.thread.ShutdownAccess
+jdk.internal.thread.ThreadAccess
 sun.nio.ch.ByteBuffer$_aliases
 sun.nio.ch.EPollSelectorImpl$_init
 sun.nio.ch.EPollSelectorImpl$_runtime


### PR DESCRIPTION
This is not in any way ready yet (it doesn't even compile), but I just wanted to post some progress so that people can start having a look and raising red flags if something is clearly looking wrong. I'll maintain this PR as I make more progress.

This patch introduces a `struct gc` structure which different implementations may populate. This could allow us to have more than one selectable implementation at run time, which might or might not be a good idea. For now the GC structure is selected using a compile-time string name.

GCs are currently limited to operating from a single GC thread for simplicity. Some of the safepoint handshake between GC threads and the program threads are a little iffy at the moment; this part needs to be handled carefully so I'll probably revisit that once the basic algorithm is working.

I'm also figuring out the best way to communicate the address of some of our significant regions back to the GC. I'm leaning towards intrinsics at the moment just for expediency.

A lot of the non-public things that I put on `Thread` I want to move to a `ThreadNative` class which would be a public class on a non-exported package. This will make it a lot easier for JDK things to access these structures without adding public members to `java.lang` or requiring many alias classes.